### PR TITLE
[Issue #8] sshd side container for the vm-file-restore

### DIFF
--- a/side-containers/sshd/.dockerignore
+++ b/side-containers/sshd/.dockerignore
@@ -1,0 +1,36 @@
+# Ignore all markdown files except README.md in root
+*.md
+!README.md
+
+# Ignore git files
+.git
+.gitignore
+.gitattributes
+
+# Ignore CI/CD files
+.github
+.gitlab-ci.yml
+
+# Ignore test files
+test-*
+*_test.sh
+
+# Ignore build artifacts
+*.tar
+*.tar.gz
+*.zip
+
+# Ignore editor/IDE files
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# Ignore OS files
+.DS_Store
+Thumbs.db
+
+# Ignore oadp sample keys
+oadp-key
+oadp-key.pub

--- a/side-containers/sshd/Containerfile
+++ b/side-containers/sshd/Containerfile
@@ -1,0 +1,110 @@
+# Build stage - compile Go binary
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
+
+# Use the default working directory in go-toolset (user has write access)
+WORKDIR /opt/app-root/src
+COPY --chown=1001:0 oadp-sshd.go .
+
+# Build static binary for multi-arch
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o oadp-sshd oadp-sshd.go
+
+# Final stage
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+LABEL maintainer="OADP Team" \
+      description="Secure SSHD container for OADP VM File Restore with chroot jail" \
+      summary="Provides read-only SSH/SFTP/rsync access to backup files" \
+      io.openshift.tags="oadp,backup,restore,ssh,sftp,rsync" \
+      io.k8s.description="Multi-architecture SSHD container for secure read-only access to VM backup files"
+
+# Install required packages
+RUN microdnf install -y \
+    openssh-server \
+    openssh-clients \
+    shadow-utils \
+    passwd \
+    rsync \
+    bash \
+    findutils \
+    && microdnf clean all
+
+# Create chroot directory structure at /oadp
+RUN mkdir -p /oadp/bin \
+    && mkdir -p /oadp/lib \
+    && mkdir -p /oadp/lib64 \
+    && mkdir -p /oadp/usr/lib \
+    && mkdir -p /oadp/usr/lib64 \
+    && mkdir -p /oadp/usr/libexec/openssh \
+    && mkdir -p /oadp/dev \
+    && mkdir -p /oadp/.ssh
+
+# Copy binaries into chroot
+RUN cp /usr/bin/rsync /oadp/bin/ \
+    && cp /usr/bin/scp /oadp/bin/ \
+    && cp /bin/bash /oadp/bin/ \
+    && cp /usr/libexec/openssh/sftp-server /oadp/usr/libexec/openssh/
+
+# Copy library dependencies for all architectures (x86_64 and aarch64)
+# This script handles both lib and lib64 paths automatically
+RUN for binary in /usr/bin/rsync /usr/bin/scp /bin/bash /usr/libexec/openssh/sftp-server; do \
+        echo "Copying dependencies for $binary..."; \
+        ldd "$binary" 2>/dev/null | grep "=>" | awk '{print $3}' | while read lib; do \
+            if [ -f "$lib" ]; then \
+                # Preserve the original directory structure (lib vs lib64, etc.) \
+                case "$lib" in \
+                    /lib64/*) mkdir -p /oadp/lib64 && cp -L "$lib" /oadp/lib64/ 2>/dev/null || true ;; \
+                    /lib/*) mkdir -p /oadp/lib && cp -L "$lib" /oadp/lib/ 2>/dev/null || true ;; \
+                    /usr/lib64/*) mkdir -p /oadp/usr/lib64 && cp -L "$lib" /oadp/usr/lib64/ 2>/dev/null || true ;; \
+                    /usr/lib/*) mkdir -p /oadp/usr/lib && cp -L "$lib" /oadp/usr/lib/ 2>/dev/null || true ;; \
+                esac; \
+            fi; \
+        done; \
+        # Copy dynamic linker (ld-linux-*.so.*) \
+        ldd "$binary" 2>/dev/null | grep -E "ld-linux|ld.so" | awk '{print $1}' | while read linker; do \
+            if [ -f "$linker" ]; then \
+                case "$linker" in \
+                    /lib64/*) mkdir -p /oadp/lib64 && cp -L "$linker" /oadp/lib64/ 2>/dev/null || true ;; \
+                    /lib/*) mkdir -p /oadp/lib && cp -L "$linker" /oadp/lib/ 2>/dev/null || true ;; \
+                esac; \
+            fi; \
+        done; \
+    done
+
+# Note: Device nodes are created at runtime in entrypoint.sh
+# Cannot create them here because mknod requires CAP_MKNOD capability
+
+# Copy compiled Go binary from builder stage
+COPY --from=builder /opt/app-root/src/oadp-sshd /oadp/bin/oadp-sshd
+
+# Copy entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+
+# Make binaries executable
+# Note: oadp-sshd is 711, but DAC_READ_SEARCH capability allows downloading it anyway
+RUN chmod 711 /oadp/bin/oadp-sshd \
+    && chmod +x /entrypoint.sh \
+    && chmod 755 /oadp/bin/rsync \
+    && chmod 755 /oadp/bin/scp \
+    && chmod 755 /oadp/bin/bash \
+    && chmod 755 /oadp/usr/libexec/openssh/sftp-server
+
+# Set proper ownership for chroot directory
+RUN chown root:root /oadp \
+    && chmod 755 /oadp
+
+# Create a template directory with base /etc files
+# We'll copy these to /etc at runtime (when /etc is mounted as emptyDir)
+RUN mkdir -p /etc-template \
+    && cp -a /etc/passwd /etc/group /etc/shadow /etc/gshadow /etc/nsswitch.conf /etc-template/ \
+    && cp -a /etc/pam.d /etc-template/ \
+    && ls -la /etc-template/ \
+    && echo "Template files created successfully"
+
+# Expose SSH port
+EXPOSE 2222
+
+# Run as root (required for sshd and chroot)
+USER root
+
+# Entrypoint
+ENTRYPOINT ["/entrypoint.sh"]

--- a/side-containers/sshd/Makefile
+++ b/side-containers/sshd/Makefile
@@ -1,0 +1,179 @@
+# Makefile for building OADP VM File Restore SSHD container
+
+# Default image name and tag
+IMAGE_REGISTRY ?= quay.io
+IMAGE_ORG ?= migtools
+IMAGE_NAME ?= oadp-vmfr-sshd
+IMAGE_TAG ?= latest
+IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_ORG)/$(IMAGE_NAME):$(IMAGE_TAG)
+
+# Container tool (podman or docker)
+# Auto-detect: prefer podman if available, fallback to docker
+CONTAINER_TOOL ?= $(shell command -v podman 2>/dev/null || echo docker)
+
+# Platforms for multi-arch builds
+PLATFORMS ?= linux/amd64,linux/arm64
+
+# Buildx builder name
+BUILDER_NAME ?= oadp-multiarch-builder
+
+.PHONY: help
+help: ## Display this help
+	@echo "Available targets:"
+	@awk 'BEGIN {FS = ":.*##"; printf "\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)
+
+.PHONY: build
+build: ## Build the container image
+	@echo "Building image $(IMAGE) using $(CONTAINER_TOOL)..."
+	$(CONTAINER_TOOL) build -t $(IMAGE) -f Containerfile .
+	@echo "Image built successfully: $(IMAGE)"
+
+.PHONY: build-podman
+build-podman: ## Build the container image using podman
+	@echo "Building image $(IMAGE) using podman..."
+	podman build -t $(IMAGE) -f Containerfile .
+	@echo "Image built successfully: $(IMAGE)"
+
+.PHONY: build-docker
+build-docker: ## Build the container image using docker
+	@echo "Building image $(IMAGE) using docker..."
+	docker build -t $(IMAGE) -f Containerfile .
+	@echo "Image built successfully: $(IMAGE)"
+
+.PHONY: push
+push: ## Push the container image to registry
+	@echo "Pushing image $(IMAGE) using $(CONTAINER_TOOL)..."
+	$(CONTAINER_TOOL) push $(IMAGE)
+	@echo "Image pushed successfully: $(IMAGE)"
+
+.PHONY: push-podman
+push-podman: ## Push the container image using podman
+	@echo "Pushing image $(IMAGE) using podman..."
+	podman push $(IMAGE)
+	@echo "Image pushed successfully: $(IMAGE)"
+
+.PHONY: push-docker
+push-docker: ## Push the container image using docker
+	@echo "Pushing image $(IMAGE) using docker..."
+	docker push $(IMAGE)
+	@echo "Image pushed successfully: $(IMAGE)"
+
+.PHONY: build-push
+build-push: build push ## Build and push the container image
+
+.PHONY: clean
+clean: ## Clean up local images
+	@echo "Cleaning up local images..."
+	$(CONTAINER_TOOL) rmi $(IMAGE) 2>/dev/null || true
+
+.PHONY: login-quay
+login-quay: ## Login to quay.io registry
+	@echo "Logging into quay.io..."
+	$(CONTAINER_TOOL) login quay.io
+
+.PHONY: info
+info: ## Show build information
+	@echo "Container Tool: $(CONTAINER_TOOL)"
+	@echo "Image: $(IMAGE)"
+	@echo "Registry: $(IMAGE_REGISTRY)"
+	@echo "Organization: $(IMAGE_ORG)"
+	@echo "Name: $(IMAGE_NAME)"
+	@echo "Tag: $(IMAGE_TAG)"
+	@echo "Platforms: $(PLATFORMS)"
+	@echo "Builder Name: $(BUILDER_NAME)"
+
+##@ Multi-Architecture Builds
+
+.PHONY: buildx-create
+buildx-create: ## Create buildx builder for multi-arch builds (docker only)
+	@echo "Creating buildx builder: $(BUILDER_NAME)..."
+	@if [ "$(CONTAINER_TOOL)" = "docker" ]; then \
+		docker buildx create --name $(BUILDER_NAME) --use --bootstrap 2>/dev/null || \
+		docker buildx use $(BUILDER_NAME); \
+		echo "Buildx builder created/activated: $(BUILDER_NAME)"; \
+	else \
+		echo "Note: Podman doesn't require buildx setup"; \
+	fi
+
+.PHONY: buildx-remove
+buildx-remove: ## Remove buildx builder
+	@echo "Removing buildx builder: $(BUILDER_NAME)..."
+	@if [ "$(CONTAINER_TOOL)" = "docker" ]; then \
+		docker buildx rm $(BUILDER_NAME) || true; \
+	fi
+
+.PHONY: build-multiarch
+build-multiarch: ## Build multi-architecture image (amd64 and arm64)
+	@echo "Building multi-arch image $(IMAGE) for platforms: $(PLATFORMS)"
+	@if [ "$(CONTAINER_TOOL)" = "podman" ]; then \
+		echo "Building with podman..."; \
+		podman build \
+			--platform $(PLATFORMS) \
+			--manifest $(IMAGE) \
+			-f Containerfile .; \
+	else \
+		echo "Building with docker buildx..."; \
+		docker buildx build \
+			--platform $(PLATFORMS) \
+			-t $(IMAGE) \
+			-f Containerfile \
+			--load \
+			.; \
+	fi
+	@echo "Multi-arch image built successfully: $(IMAGE)"
+
+.PHONY: build-push-multiarch
+build-push-multiarch: ## Build and push multi-architecture image
+	@echo "Building and pushing multi-arch image $(IMAGE) for platforms: $(PLATFORMS)"
+	@if [ "$(CONTAINER_TOOL)" = "podman" ]; then \
+		echo "Building with podman..."; \
+		podman build \
+			--platform $(PLATFORMS) \
+			--manifest $(IMAGE) \
+			-f Containerfile .; \
+		echo "Pushing manifest..."; \
+		podman manifest push $(IMAGE) $(IMAGE); \
+	else \
+		echo "Building with docker buildx..."; \
+		docker buildx build \
+			--platform $(PLATFORMS) \
+			-t $(IMAGE) \
+			-f Containerfile \
+			--push \
+			.; \
+	fi
+	@echo "Multi-arch image built and pushed successfully: $(IMAGE)"
+
+.PHONY: build-amd64
+build-amd64: ## Build image for amd64/x86_64 only
+	@echo "Building amd64 image $(IMAGE)..."
+	$(CONTAINER_TOOL) build \
+		--platform linux/amd64 \
+		-t $(IMAGE)-amd64 \
+		-f Containerfile .
+	@echo "AMD64 image built: $(IMAGE)-amd64"
+
+.PHONY: build-arm64
+build-arm64: ## Build image for arm64/aarch64 only
+	@echo "Building arm64 image $(IMAGE)..."
+	$(CONTAINER_TOOL) build \
+		--platform linux/arm64 \
+		-t $(IMAGE)-arm64 \
+		-f Containerfile .
+	@echo "ARM64 image built: $(IMAGE)-arm64"
+
+.PHONY: inspect-manifest
+inspect-manifest: ## Inspect the multi-arch manifest
+	@echo "Inspecting manifest for $(IMAGE)..."
+	@if [ "$(CONTAINER_TOOL)" = "podman" ]; then \
+		podman manifest inspect $(IMAGE); \
+	else \
+		docker buildx imagetools inspect $(IMAGE); \
+	fi
+
+# Example usage with custom values:
+# make build IMAGE_TAG=v1.0.0
+# make build-push IMAGE_ORG=myorg IMAGE_TAG=dev
+# make build CONTAINER_TOOL=docker
+# make build-multiarch PLATFORMS=linux/amd64,linux/arm64
+# make build-push-multiarch IMAGE_TAG=v1.0.0

--- a/side-containers/sshd/README.md
+++ b/side-containers/sshd/README.md
@@ -1,0 +1,297 @@
+# OADP VM File Restore SSHD Container
+
+Secure SSH/SFTP/rsync container for read-only access to OADP VM backup files with chroot jail isolation.
+
+## Features
+
+**Supported Operations:**
+- ✅ rsync (download/read-only), scp (download only), sftp (browsing and download)
+- ❌ Interactive shell, write/upload operations, port forwarding, tunneling
+
+**Security:**
+- Chroot jail at `/oadp` with Go-based forced command validation
+- Read-only root filesystem and data mounts
+- Public key authentication only, all SSH features disabled except file transfer
+- Minimal capabilities (7 granted: AUDIT_WRITE, CHOWN, DAC_READ_SEARCH, MKNOD, SETUID, SETGID, SYS_CHROOT)
+- Multi-architecture support (amd64, arm64)
+
+## Building
+
+### Using Make (Recommended)
+
+```bash
+# Single-arch build and push (auto-detects podman/docker)
+make build
+make push
+
+# Multi-arch build and push
+make build-push-multiarch
+
+# Architecture-specific builds
+make build-amd64
+make build-arm64
+
+# Custom image settings
+make build IMAGE_TAG=v1.0.0 IMAGE_ORG=myorg
+
+# Show targets and configuration
+make help
+make info
+```
+
+### Manual Build
+
+**Single-arch:**
+```bash
+# Podman or Docker
+podman build -t quay.io/migtools/oadp-vmfr-sshd:latest -f Containerfile .
+docker build -t quay.io/migtools/oadp-vmfr-sshd:latest -f Containerfile .
+```
+
+**Multi-arch:**
+```bash
+# Podman (native multi-arch support)
+podman build --platform linux/amd64,linux/arm64 \
+  --manifest quay.io/migtools/oadp-vmfr-sshd:latest -f Containerfile .
+podman manifest push quay.io/migtools/oadp-vmfr-sshd:latest
+
+# Docker (requires buildx)
+docker buildx create --name multiarch-builder --use  # One-time setup
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t quay.io/migtools/oadp-vmfr-sshd:latest -f Containerfile --push .
+```
+
+**Supported Platforms:** linux/amd64, linux/arm64
+
+### Pushing to Registry
+
+```bash
+# Using Make
+make login-quay
+make build-push
+
+# Manual
+podman login quay.io  # or docker login
+podman push quay.io/migtools/oadp-vmfr-sshd:latest
+```
+
+## Deployment
+
+### Configuration
+
+The container reads configuration from mounted secrets at `/ssh-config/`:
+- `username` - SSH username (any valid name, user created at runtime with UID/GID 1001)
+- `authorized_keys` - SSH public keys for authentication
+
+### Required Mounts
+
+1. **SSH Config:** `/ssh-config/` (secret with username file)
+2. **SSH Keys:** `/oadp/.ssh/authorized_keys` (mount authorized_keys from secret using subPath)
+3. **Backup Data:** `/oadp/restores/` (PVC with backup data)
+4. **Tmpfs (for read-only root FS):** `/etc`, `/run`, `/tmp`, `/oadp/dev` (all emptyDir)
+
+### Kubernetes Pod Example
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: file-serving-pod
+spec:
+  securityContext:
+    fsGroup: 1001
+  containers:
+  - name: sshd
+    image: quay.io/migtools/oadp-vmfr-sshd:latest
+    ports:
+    - containerPort: 2222
+      name: ssh
+    volumeMounts:
+    - name: restores-volume
+      mountPath: /oadp/restores
+      readOnly: true
+    - name: ssh-secret
+      mountPath: /ssh-config
+      readOnly: true
+    - name: ssh-secret
+      mountPath: /oadp/.ssh/authorized_keys
+      subPath: authorized_keys
+      readOnly: true
+    - name: ssh-etc
+      mountPath: /etc
+    - name: ssh-run
+      mountPath: /run
+    - name: ssh-tmp
+      mountPath: /tmp
+    - name: ssh-dev
+      mountPath: /oadp/dev
+    securityContext:
+      runAsUser: 0
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        add: [AUDIT_WRITE, CHOWN, DAC_READ_SEARCH, MKNOD, SETUID, SETGID, SYS_CHROOT]
+        drop: [ALL]
+  volumes:
+  - name: restores-volume
+    persistentVolumeClaim:
+      claimName: restores-pvc
+  - name: ssh-secret
+    secret:
+      secretName: ssh-oadp
+      defaultMode: 0400
+  - name: ssh-etc
+    emptyDir: {medium: Memory, sizeLimit: 10Mi}
+  - name: ssh-run
+    emptyDir: {medium: Memory, sizeLimit: 10Mi}
+  - name: ssh-tmp
+    emptyDir: {medium: Memory, sizeLimit: 50Mi}
+  - name: ssh-dev
+    emptyDir: {medium: Memory, sizeLimit: 1Mi}
+```
+
+## Testing
+
+### Sample Deployment
+
+A complete sample deployment with OpenShift manifests is available in the `sample-deployment/` directory.
+
+#### Quick Start
+
+```bash
+# Step 1: Generate SSH key pair
+ssh-keygen -t rsa -b 4096 -f oadp-key -C "oadp@openshift-adp" -N ""
+
+# Step 2: Create namespace
+oc apply -f sample-deployment/1_namespace.yaml
+
+# Step 3: Create SSH secret with your key
+oc create secret generic ssh-oadp -n vmfr-pod-test \
+  --from-literal=username=oadp \
+  --from-file=authorized_keys=oadp-key.pub
+
+# Step 4: Create PVC for restore data
+oc apply -f sample-deployment/3_pvc.yaml
+
+# Step 5: Deploy the file serving pod
+oc apply -f sample-deployment/4_serving_pod.yaml
+
+# Step 6: Port forward to access SSH - after the pod to starts
+oc port-forward -n vmfr-pod-test pod/file-serving-pod 2222:2222
+
+# Step 7: Download the files using instructions from below paragraph
+```
+
+### Using the Deployment
+
+After deploying, port forward and access files:
+
+```bash
+# Download with scp
+scp -P 2222 -i oadp-key oadp@localhost:/restores/sampledata/vm1/disk1/data.txt /tmp/
+
+# Download with rsync
+rsync -avz -e "ssh -p 2222 -i oadp-key" oadp@localhost:/restores/sampledata/ /tmp/vm-restored-backup/
+
+# Browse with sftp
+sftp -P 2222 -i oadp-key oadp@localhost
+```
+
+## Development
+
+### File Structure
+
+```
+side-containers/sshd/
+├── Containerfile    # Multi-stage build (Go compile + runtime)
+├── entrypoint.sh    # Container entrypoint
+├── oadp-sshd.go     # SSH command validator (Go)
+├── Makefile         # Build automation
+└── README.md        # This file
+```
+
+### Chroot Environment
+
+The chroot jail at `/oadp`:
+```
+/oadp/
+├── .ssh/authorized_keys    # Mounted from secret
+├── bin/{bash,rsync,scp,oadp-sshd}
+├── etc/{passwd,group,nsswitch.conf}  # Created at runtime
+├── lib/, lib64/, usr/lib/, usr/lib64/  # Shared libraries
+├── usr/libexec/openssh/sftp-server
+├── dev/{null,zero}         # Created at runtime
+└── restores/               # Mounted PVC
+```
+
+**Note:** The container uses multi-stage build (Go compile → minimal runtime). The `oadp-sshd` binary (chmod 711) validates all SSH commands but can be downloaded due to `DAC_READ_SEARCH` capability. Security relies on defense-in-depth (read-only mounts, chroot, forced command), not obscurity.
+
+### Modifying Code
+
+After modifying `entrypoint.sh` or `oadp-sshd.go`:
+```bash
+make build
+```
+
+## Security Considerations
+
+### Defense-in-Depth Model
+
+**Why container runs as root (UID 0):**
+- OpenSSH requires root for authentication and privilege separation
+- `chroot()` system call requires root even with SYS_CHROOT capability
+- Dynamic user creation (`useradd`/`groupadd`) requires root
+- File access with `DAC_READ_SEARCH` requires root context
+
+**How security is maintained despite root:**
+1. **Read-only root filesystem** - Cannot modify container or install backdoors
+2. **Read-only data mount** - Cannot modify backup data (kernel-enforced)
+3. **Minimal capabilities** - Only 7 granted (vs ~40 available), all others dropped
+4. **No privilege escalation** - Cannot gain additional capabilities
+5. **Chroot isolation** - Users confined to `/oadp` directory
+6. **Forced command** - Go binary validates all SSH commands, blocks shell access
+7. **Ephemeral state** - All writable dirs are tmpfs, lost on restart
+
+### Required Capabilities
+
+- **AUDIT_WRITE** - PAM audit logging (RHEL requirement)
+- **CHOWN** - Set ownership during initialization
+- **DAC_READ_SEARCH** - Read backup files regardless of ownership/permissions
+- **MKNOD** - Create device nodes in chroot at runtime
+- **SETUID/SETGID** - SSH privilege dropping
+- **SYS_CHROOT** - Enable chroot jail
+
+**Note:** `DAC_READ_SEARCH` allows users to download all files in chroot (including `oadp-sshd` binary). Security does not rely on hiding validation logic.
+
+### Attack Surface
+
+With valid SSH credentials, users can:
+- ✅ Download backup files (intended functionality)
+
+Users cannot:
+- ❌ Get interactive shell (forced command blocks)
+- ❌ Execute arbitrary commands (validated by oadp-sshd)
+- ❌ Upload or modify files (read-only mounts)
+- ❌ Persist backdoors (read-only filesystem + ephemeral tmpfs)
+- ❌ Escape chroot (proper configuration required)
+
+## Customization
+
+### Using Different Username
+
+The SSH username can be customized. Edit the secret:
+
+```yaml
+stringData:
+  username: myuser  # Can be: oadp, restore, backup, or any valid username
+  authorized_keys: |
+    ssh-rsa AAAA... myuser@example.com
+```
+
+The user will be dynamically created at container startup with:
+- Username: From the secret
+- UID: 1001 (fixed)
+- GID: 1001 (fixed)
+- Home: `/oadp` (chroot jail)
+
+This allows you to use different usernames while maintaining consistent file ownership.

--- a/side-containers/sshd/entrypoint.sh
+++ b/side-containers/sshd/entrypoint.sh
@@ -1,0 +1,270 @@
+#!/bin/bash
+set -e
+
+echo "==================================================================="
+echo "OADP VM File Restore SSHD Container Starting"
+echo "==================================================================="
+
+# Read username from secret (mounted at /ssh-config)
+if [ ! -f /ssh-config/username ]; then
+    echo "ERROR - SSH username not found in secret at /ssh-config/username"
+    exit 1
+fi
+
+if [ ! -f /ssh-config/authorized_keys ]; then
+    echo "ERROR - SSH authorized_keys not found in secret at /ssh-config/authorized_keys"
+    exit 1
+fi
+
+SSH_USER=$(cat /ssh-config/username)
+OADP_UID=1001
+OADP_GID=1001
+
+echo "Configuring SSH for user - ${SSH_USER} (UID ${OADP_UID}, GID ${OADP_GID})"
+
+# Initialize /etc with base files from template
+# This is needed because /etc is mounted as emptyDir (writable)
+if [ ! -f /etc/passwd ]; then
+    echo "Initializing /etc from template..."
+
+    # Check template directory
+    echo "Checking /etc-template..."
+    ls -la /etc-template/ || { echo "ERROR: Cannot list /etc-template"; exit 1; }
+
+    # Check current /etc
+    echo "Current /etc contents before copy:"
+    ls -la /etc/ || true
+
+    # Copy all files from template
+    echo "Copying files from /etc-template to /etc..."
+    cp -av /etc-template/* /etc/ || { echo "ERROR: Copy failed"; exit 1; }
+
+    # Fix permissions so groupadd/useradd can write to these files
+    echo "Setting proper permissions on /etc files..."
+    chmod 644 /etc/passwd /etc/group
+    chmod 600 /etc/shadow /etc/gshadow
+
+    # Check /etc after copy
+    echo "Current /etc contents after copy and permission fix:"
+    ls -la /etc/
+
+    # Verify required files exist and are writable
+    for file in passwd group shadow gshadow nsswitch.conf; do
+        if [ ! -f /etc/$file ]; then
+            echo "ERROR - /etc/$file is missing after template copy"
+            exit 1
+        fi
+        echo "Verified /etc/$file exists"
+    done
+
+    # Verify PAM directory exists
+    if [ ! -d /etc/pam.d ]; then
+        echo "ERROR - /etc/pam.d directory is missing after template copy"
+        exit 1
+    fi
+    echo "Verified /etc/pam.d exists"
+
+    echo "/etc initialized successfully"
+fi
+
+# Create the SSH user with the name from the secret
+# Check if user already exists
+if id "${SSH_USER}" >/dev/null 2>&1; then
+    echo "User ${SSH_USER} already exists"
+else
+    echo "Creating user ${SSH_USER}..."
+    # Create group first
+    if ! getent group ${SSH_USER} >/dev/null 2>&1; then
+        groupadd -g ${OADP_GID} ${SSH_USER}
+    fi
+    # Create user with flags to avoid lastlog and mailbox warnings
+    # -l: do not add user to lastlog database (read-only filesystem)
+    # -M: do not create home directory
+    # Redirect stderr to suppress mailbox creation warning
+    useradd -l -u ${OADP_UID} -g ${OADP_GID} -d /oadp -s /bin/bash -M ${SSH_USER} 2>&1 | grep -v "Creating mailbox file" || true
+    echo "Created user ${SSH_USER} (UID ${OADP_UID}, GID ${OADP_GID})"
+
+    # Unlock the account for SSH key authentication
+    # PAM requires the account to have a password (even if unused) to not be locked.
+    # Set a random password that will never be used (PasswordAuthentication is disabled).
+    # Generate a random 32-character password
+    RANDOM_PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32)
+    echo "${SSH_USER}:${RANDOM_PASSWORD}" | chpasswd
+    echo "Account unlocked with random password (password auth is disabled)"
+    unset RANDOM_PASSWORD  # Clear from memory
+fi
+
+# Setup SSH directory for the user inside chroot
+# Note: authorized_keys is mounted directly from secret at /oadp/.ssh/authorized_keys
+# The directory is created automatically by the mount, we just verify it exists
+echo "Configuring SSH directory in /oadp/.ssh..."
+
+# Verify the directory exists (created by Kubernetes mount)
+if [ -d /oadp/.ssh ]; then
+    echo "SSH directory exists - authorized_keys mounted from secret"
+    ls -la /oadp/.ssh/
+else
+    echo "ERROR - /oadp/.ssh directory not found (mount failed?)"
+    exit 1
+fi
+
+# Note: We cannot change ownership of the mount point, but StrictModes is disabled
+# in sshd_config to allow this setup to work securely with other restrictions
+
+# Create device nodes in chroot /dev (needed for scp and other tools)
+# /oadp/dev is mounted as emptyDir, so we can create device nodes at runtime
+if [ ! -e /oadp/dev/null ]; then
+    echo "Creating device nodes in /oadp/dev..."
+    mknod -m 666 /oadp/dev/null c 1 3
+    mknod -m 666 /oadp/dev/zero c 1 5
+    echo "Device nodes created"
+fi
+
+# Create minimal /etc files inside chroot for user lookups
+# scp and other tools need to resolve UIDs to usernames
+mkdir -p /oadp/etc
+echo "Creating minimal passwd/group files in chroot /oadp/etc..."
+
+# Create minimal passwd file with root and oadp user
+# Note: Shell is set to /bin/bash but ForceCommand prevents it from being used
+cat > /oadp/etc/passwd << EOF
+root:x:0:0:root:/root:/bin/bash
+${SSH_USER}:x:${OADP_UID}:${OADP_GID}:OADP User:/oadp:/bin/bash
+EOF
+
+# Create minimal group file
+cat > /oadp/etc/group << EOF
+root:x:0:
+${SSH_USER}:x:${OADP_GID}:
+EOF
+
+# Create minimal nsswitch.conf for chroot
+cat > /oadp/etc/nsswitch.conf << 'EOF'
+passwd:     files
+group:      files
+EOF
+
+chmod 644 /oadp/etc/passwd /oadp/etc/group /oadp/etc/nsswitch.conf
+chown root:root /oadp/etc/passwd /oadp/etc/group /oadp/etc/nsswitch.conf
+echo "Chroot /etc files created"
+
+# Create SSH config directory (needed because /etc is emptyDir)
+mkdir -p /etc/ssh
+
+# Create a simplified PAM configuration for SSHD that works in containers
+# The default RHEL PAM config has SELinux and security modules that don't work in containers
+cat > /etc/pam.d/sshd << 'EOFPAM'
+#%PAM-1.0
+# Simplified PAM configuration for containerized SSHD
+# Removed SELinux, sepermit, and other modules that require full system access
+
+# Authentication
+auth       required     pam_env.so
+auth       sufficient   pam_unix.so nullok
+auth       required     pam_deny.so
+
+# Account management
+account    required     pam_unix.so
+
+# Password management (not used with key-only auth, but needed by PAM)
+password   required     pam_unix.so
+
+# Session management
+session    required     pam_unix.so
+session    optional     pam_motd.so
+EOFPAM
+
+echo "Created simplified PAM configuration for SSHD (container-compatible)"
+
+# Generate host keys if they don't exist
+# Note: Keys are generated at runtime for security - each container instance
+# has unique keys. Shipping keys in the image would mean all instances share
+# the same keys, which is a security vulnerability.
+if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then
+    echo "Generating SSH host keys..."
+    ssh-keygen -A
+fi
+
+# Create run directory for sshd
+mkdir -p /run/sshd
+
+# Create sshd_config with chroot and forced command
+cat > /etc/ssh/sshd_config << EOF
+# Secure Read-Only File Transfer Configuration for OADP with Chroot
+Port 2222
+
+# Security settings
+PermitRootLogin no
+PubkeyAuthentication yes
+PasswordAuthentication no
+ChallengeResponseAuthentication no
+KbdInteractiveAuthentication no
+# Enable PAM - required for RHEL/UBI
+# Provides session management, audit logging, and account policy enforcement
+UsePAM yes
+
+# Disable strict mode checking - safe in this context because:
+# - authorized_keys is mounted from Kubernetes secret (read-only)
+# - Mount point ownership cannot be changed
+# - Container has chroot jail, forced command, and read-only filesystem
+# - All other security controls remain in place
+StrictModes no
+
+# Disable all forwarding and tunneling
+X11Forwarding no
+AllowTcpForwarding no
+AllowStreamLocalForwarding no
+PermitTunnel no
+GatewayPorts no
+
+# Disable unnecessary features
+PrintMotd no
+PrintLastLog no
+PermitUserEnvironment no
+
+# SFTP subsystem
+Subsystem sftp internal-sftp
+
+# Chroot and restrict to read-only operations via forced command
+Match User ${SSH_USER}
+    ChrootDirectory /oadp
+    ForceCommand /bin/oadp-sshd
+EOF
+
+echo "==================================================================="
+echo "SSHD Configuration Complete - READ-ONLY FILE TRANSFER WITH CHROOT"
+echo "==================================================================="
+echo "SSH User - ${SSH_USER} (UID ${OADP_UID})"
+echo "SSH Port - 2222"
+echo "Chroot Jail - /oadp (user sees it as /)"
+echo ""
+echo "Allowed Operations -"
+echo "  ✓ rsync (read-only) - rsync -avz ${SSH_USER}@host:/restores/ /local/"
+echo "  ✓ scp (download) - scp ${SSH_USER}@host:/restores/file /local/"
+echo "  ✓ sftp - sftp ${SSH_USER}@host"
+echo "  ✗ Interactive shell - DISABLED"
+echo "  ✗ Write operations - DISABLED"
+echo ""
+echo "Security -"
+echo "  - Chroot jail - User confined to /oadp directory"
+echo "  - Read-only mount on /restores/"
+echo "  - Can read ALL files regardless of ownership (DAC_READ_SEARCH)"
+echo "  - Forced command wrapper blocks unauthorized operations"
+echo "  - No shell access, no port forwarding, no tunneling"
+echo ""
+echo "Data Location (inside chroot) - /restores/"
+echo "Authentication - Public key only"
+echo "==================================================================="
+
+# Verify /oadp/restores exists (should be mounted from PVC)
+if [ -d /oadp/restores ]; then
+    echo "Checking /oadp/restores ownership -"
+    ls -ld /oadp/restores/ || true
+else
+    echo "WARNING - /oadp/restores does not exist (PVC not mounted?)"
+fi
+
+echo "Starting SSHD on port 2222..."
+
+# Start sshd in foreground
+exec /usr/sbin/sshd -D -e

--- a/side-containers/sshd/oadp-sshd.go
+++ b/side-containers/sshd/oadp-sshd.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"syscall"
+)
+
+const (
+	sftpServer = "/usr/libexec/openssh/sftp-server"
+	rsyncBin   = "/bin/rsync"
+	scpBin     = "/bin/scp"
+	bashBin    = "/bin/bash"
+)
+
+func main() {
+	// Get the original SSH command
+	cmd := os.Getenv("SSH_ORIGINAL_COMMAND")
+
+	// Log to stderr (goes to container logs)
+	fmt.Fprintf(os.Stderr, "DEBUG: Command received: %s\n", cmd)
+
+	// If no command, deny interactive shell
+	if cmd == "" {
+		fmt.Fprintln(os.Stderr, "ERROR - Interactive shell access is disabled.")
+		fmt.Fprintln(os.Stderr, "Allowed operations: rsync (read-only), scp (download only), sftp")
+		os.Exit(1)
+	}
+
+	// Handle SFTP
+	if cmd == "internal-sftp" {
+		execCommand(sftpServer, "-d", "/restores")
+	}
+
+	// Handle rsync (read-only mode only)
+	if isRsyncCommand(cmd) {
+		handleRsync(cmd)
+	}
+
+	// Handle scp (download mode only)
+	if isScpCommand(cmd) {
+		handleScp(cmd)
+	}
+
+	// Deny everything else
+	fmt.Fprintf(os.Stderr, "ERROR - Command not allowed: %s\n", cmd)
+	fmt.Fprintln(os.Stderr, "Allowed operations: rsync (read-only), scp (download), sftp")
+	os.Exit(1)
+}
+
+// isRsyncCommand checks if command starts with "rsync --server"
+func isRsyncCommand(cmd string) bool {
+	match, _ := regexp.MatchString(`^rsync\s+--server`, cmd)
+	return match
+}
+
+// isScpCommand checks if command starts with "scp"
+func isScpCommand(cmd string) bool {
+	return strings.HasPrefix(cmd, "scp ")
+}
+
+// handleRsync validates and executes rsync in read-only mode
+func handleRsync(cmd string) {
+	// Check if it's sender mode (read-only)
+	isSender, _ := regexp.MatchString(`--sender`, cmd)
+
+	if !isSender {
+		fmt.Fprintln(os.Stderr, "ERROR - rsync write operations are disabled.")
+		os.Exit(1)
+	}
+
+	// Replace rsync with full path
+	cmdWithPath := strings.Replace(cmd, "rsync", rsyncBin, 1)
+	execBash(cmdWithPath)
+}
+
+// handleScp validates and executes scp in download mode only
+func handleScp(cmd string) {
+	hasDownloadFlag, _ := regexp.MatchString(`-f`, cmd)
+	hasUploadFlag, _ := regexp.MatchString(`-t`, cmd)
+
+	if hasDownloadFlag {
+		// Download mode - ALLOW
+		cmdWithPath := strings.Replace(cmd, "scp", scpBin, 1)
+		execBash(cmdWithPath)
+	} else if hasUploadFlag {
+		// Upload mode - DENY
+		fmt.Fprintln(os.Stderr, "ERROR - scp upload is disabled (read-only)")
+		os.Exit(1)
+	} else {
+		// Invalid scp command
+		fmt.Fprintln(os.Stderr, "ERROR - Invalid scp command")
+		os.Exit(1)
+	}
+}
+
+// execCommand executes a command with arguments
+func execCommand(path string, args ...string) {
+	binary, err := exec.LookPath(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR - Command not found: %s\n", path)
+		os.Exit(1)
+	}
+
+	// Build argv with program name as argv[0]
+	argv := append([]string{path}, args...)
+
+	// Execute and replace current process
+	err = syscall.Exec(binary, argv, os.Environ())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR - Failed to execute: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// execBash executes a command string through bash
+func execBash(cmdStr string) {
+	binary, err := exec.LookPath(bashBin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR - bash not found\n")
+		os.Exit(1)
+	}
+
+	// Execute: bash -c "command string"
+	argv := []string{"bash", "-c", cmdStr}
+
+	err = syscall.Exec(binary, argv, os.Environ())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR - Failed to execute: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/side-containers/sshd/sample-deployment/1_namespace.yaml
+++ b/side-containers/sshd/sample-deployment/1_namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+  name: vmfr-pod-test

--- a/side-containers/sshd/sample-deployment/3_pvc.yaml
+++ b/side-containers/sshd/sample-deployment/3_pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: restores-pvc
+  namespace: vmfr-pod-test
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  # storageClassName: <your-storage-class>  # Uncomment and specify if needed

--- a/side-containers/sshd/sample-deployment/4_serving_pod.yaml
+++ b/side-containers/sshd/sample-deployment/4_serving_pod.yaml
@@ -1,0 +1,197 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: file-serving-pod
+  namespace: vmfr-pod-test
+  labels:
+    app: file-serving-pod
+spec:
+  # Share process namespace to allow containers to work together
+  shareProcessNamespace: true
+
+  # Pod-level security context to set fsGroup for volume ownership
+  securityContext:
+    fsGroup: 1001  # Files created in emptyDir volumes will be owned by GID 1001
+
+  initContainers:
+  # Privileged init container to create sample data and perform any mounts
+  - name: setup-data
+    image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -ex
+        # OADP user will have UID 1001
+        OADP_UID=1001
+        OADP_GID=1001
+
+        # Create sample directory structure
+        mkdir -p /restores/sampledata/vm1/disk1
+        mkdir -p /restores/sampledata/vm1/disk2
+        mkdir -p /restores/sampledata/vm2/disk1
+
+        # Create some sample files
+        echo "Sample data for VM1 disk1" > /restores/sampledata/vm1/disk1/data.txt
+        echo "Sample data for VM1 disk2" > /restores/sampledata/vm1/disk2/data.txt
+        echo "Sample data for VM2 disk1" > /restores/sampledata/vm2/disk1/data.txt
+
+        # Create a test directory to verify write permissions work
+        mkdir -p /restores/sampledata/test-write
+
+        # Set ownership to oadp user (UID 1001)
+        chown -R ${OADP_UID}:${OADP_GID} /restores/sampledata
+
+        # Set permissions to allow oadp user full access
+        chmod -R 755 /restores/sampledata
+
+        echo "Sample data setup complete - owned by UID ${OADP_UID}"
+        ls -lan /restores/sampledata/
+    volumeMounts:
+    - name: restores-volume
+      mountPath: /restores
+    securityContext:
+      privileged: true
+      runAsUser: 0
+
+  containers:
+  # Main container - non-privileged, just keeps pod running and provides access to data
+  - name: main
+    image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+    command:
+      - /bin/sh
+      - -c
+      - |
+        echo "Main container started - data is available at /restores/"
+        echo "Listing /restores/sampledata/ contents:"
+        ls -la /restores/sampledata/ 2>/dev/null || echo "Cannot list (running as non-root)"
+        # Keep container running
+        tail -f /dev/null
+    volumeMounts:
+    - name: restores-volume
+      mountPath: /restores
+    securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
+      capabilities:
+        drop:
+        - ALL
+
+  # SSHD sidecar container - provides read-only access via rsync/sftp with chroot
+  # Uses custom pre-built image with chroot environment
+  - name: sshd
+    image: quay.io/migtools/oadp-vmfr-sshd:latest
+    ports:
+    - containerPort: 2222
+      name: ssh
+      protocol: TCP
+    volumeMounts:
+    - name: restores-volume
+      mountPath: /oadp/restores
+      readOnly: true  # Read-only access for security
+    - name: ssh-secret
+      mountPath: /ssh-config
+      readOnly: true
+    # Mount authorized_keys directly from secret to avoid permission issues
+    - name: ssh-secret
+      mountPath: /oadp/.ssh/authorized_keys
+      subPath: authorized_keys
+      readOnly: true
+    - name: ssh-etc
+      mountPath: /etc
+    - name: ssh-run
+      mountPath: /run
+    - name: ssh-tmp
+      mountPath: /tmp
+    - name: ssh-dev
+      mountPath: /oadp/dev
+    - name: ssh-oadp-etc
+      mountPath: /oadp/etc
+    securityContext:
+      # SSHD needs to run as root for authentication and chroot
+      runAsUser: 0
+      # Read-only root filesystem for additional security
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      # Minimal capabilities - only what's absolutely needed
+      capabilities:
+        add:
+        - AUDIT_WRITE      # Required for PAM audit logging (RHEL requirement)
+        - CHOWN            # Required to set ownership of SSH directory at startup
+        - DAC_READ_SEARCH  # Allows reading files regardless of ownership/permissions
+        - MKNOD            # Required to create device nodes in /oadp/dev
+        - SETGID           # Required for sshd to drop privileges
+        - SETUID           # Required for sshd to drop privileges
+        - SYS_CHROOT       # Required for ChrootDirectory
+        drop:
+        - ALL
+
+  volumes:
+  - name: restores-volume
+    persistentVolumeClaim:
+      claimName: restores-pvc
+  - name: ssh-secret
+    secret:
+      secretName: ssh-oadp
+      defaultMode: 0400
+  # Tmpfs volumes for read-only root filesystem and runtime directories
+  - name: ssh-etc
+    emptyDir:
+      medium: Memory
+      sizeLimit: 10Mi  # For /etc files and user/group databases
+  - name: ssh-run
+    emptyDir:
+      medium: Memory
+      sizeLimit: 10Mi
+  - name: ssh-tmp
+    emptyDir:
+      medium: Memory
+      sizeLimit: 50Mi
+  - name: ssh-dev
+    emptyDir:
+      medium: Memory
+      sizeLimit: 1Mi  # For device nodes in chroot
+  - name: ssh-oadp-etc
+    emptyDir:
+      medium: Memory
+      sizeLimit: 1Mi  # For passwd/group files in chroot
+
+  restartPolicy: Always
+---
+# Service to expose SSH port
+apiVersion: v1
+kind: Service
+metadata:
+  name: file-serving-ssh
+  namespace: vmfr-pod-test
+  labels:
+    app: file-serving-pod
+spec:
+  selector:
+    # Add this label to the pod metadata.labels if using selector-based service
+    app: file-serving-pod
+  type: ClusterIP
+  ports:
+  - name: ssh
+    port: 2222
+    targetPort: 2222
+    protocol: TCP
+---
+# Optional: Route for external SSH access (OpenShift specific)
+# Uncomment if you need external access via OpenShift route
+# Note: SSH over Route requires passthrough
+# apiVersion: route.openshift.io/v1
+# kind: Route
+# metadata:
+#   name: file-serving-ssh
+#   namespace: vmfr-pod-test
+# spec:
+#   to:
+#     kind: Service
+#     name: file-serving-ssh
+#   port:
+#     targetPort: ssh
+#   tls:
+#     termination: passthrough


### PR DESCRIPTION
Secure SSH/SFTP/rsync container for read-only access to OADP VM backup files with chroot jail isolation.

## Features

**Supported Operations:**
- ✅ rsync (download/read-only), scp (download only), sftp (browsing and download)
- ❌ Interactive shell, write/upload operations, port forwarding, tunneling

**Security:**
- Chroot jail at `/oadp` with Go-based forced command validation
- Read-only root filesystem and data mounts
- Public key authentication only, all SSH features disabled except file transfer
- Minimal capabilities (7 granted: AUDIT_WRITE, CHOWN, DAC_READ_SEARCH, MKNOD, SETUID, SETGID, SYS_CHROOT)
- Multi-architecture support (amd64, arm64)

## Security Considerations

### Defense-in-Depth Model

**Why container runs as root (UID 0):**
- OpenSSH requires root for authentication and privilege separation
- `chroot()` system call requires root even with SYS_CHROOT capability
- Dynamic user creation (`useradd`/`groupadd`) requires root
- File access with `DAC_READ_SEARCH` requires root context

**How security is maintained despite root:**
1. **Read-only root filesystem** - Cannot modify container or install backdoors
2. **Read-only data mount** - Cannot modify backup data (kernel-enforced)
3. **Minimal capabilities** - Only 7 granted (vs ~40 available), all others dropped
4. **No privilege escalation** - Cannot gain additional capabilities
5. **Chroot isolation** - Users confined to `/oadp` directory
6. **Forced command** - Go binary validates all SSH commands, blocks shell access
7. **Ephemeral state** - All writable dirs are tmpfs, lost on restart

### Required Capabilities

- **AUDIT_WRITE** - PAM audit logging (RHEL requirement)
- **CHOWN** - Set ownership during initialization
- **DAC_READ_SEARCH** - Read backup files regardless of ownership/permissions
- **MKNOD** - Create device nodes in chroot at runtime
- **SETUID/SETGID** - SSH privilege dropping
- **SYS_CHROOT** - Enable chroot jail

**Note:** `DAC_READ_SEARCH` allows users to download all files in chroot (including `oadp-sshd` binary). Security does not rely on hiding validation logic.

Users cannot:
- ❌ Get interactive shell (forced command blocks)
- ❌ Execute arbitrary commands (validated by oadp-sshd)
- ❌ Upload or modify files (read-only mounts)
- ❌ Persist backdoors (read-only filesystem + ephemeral tmpfs)
- ❌ Escape chroot (proper configuration required)