### PR TITLE
Add filebrowser side-container for web-based file access

### DIFF
--- a/side-containers/filebrowser/README.md
+++ b/side-containers/filebrowser/README.md
@@ -1,0 +1,133 @@
+# OADP VM File Restore File Browser Container
+
+Web-based file browser container for accessing OADP VM backup files through a modern HTTPS interface.
+
+## Features
+
+- ✅ Web-based file browsing with modern UI
+- ✅ File download (single files and directories as zip)
+- ✅ File preview (images, videos, text files, PDFs)
+- ✅ Search and filtering
+- ✅ HTTPS/TLS enabled by default using OpenShift service CA
+- ✅ Non-root container (UID 1000)
+- ✅ Multi-architecture support (amd64, arm64)
+
+## Container Image
+
+**Pre-built image:** `quay.io/migtools/oadp-vmfr-filebrowser:latest`
+
+Built from: https://github.com/migtools/filebrowser
+
+## Quick Start
+
+```bash
+# Create namespace
+oc apply -f sample-deployment/1_namespace.yaml
+
+# Create credentials secret
+oc apply -f sample-deployment/2_secret.yaml
+
+# Create PVC
+oc apply -f sample-deployment/3_pvc.yaml
+
+# Deploy pod and service
+oc apply -f sample-deployment/4_serving_pod.yaml
+
+# Create route
+oc apply -f sample-deployment/5_route.yaml
+
+# Get route URL
+oc get route -n vmfr-pod-test file-serving-http -o jsonpath='{.spec.host}'
+```
+
+For default `oadp` user login with password only `oadppassword` (default values from sample secret).
+
+**IMPORTANT:** Change the password in production! Edit `2_secret.yaml` or create a new secret:
+
+```bash
+oc create secret generic filebrowser-credentials -n vmfr-pod-test \
+  --from-literal=username='oadp' \
+  --from-literal=password='your-strong-password-min-12-chars'
+```
+
+## Configuration
+
+### Authentication
+
+Credentials are stored in a Kubernetes Secret (`filebrowser-credentials`):
+- `username` - Username for login (optional, defaults to `oadp`)
+- `password` - Password (required, minimum 12 characters)
+
+When username is `oadp` or not provided, the login form pre-fills with "oadp" for convenience.
+
+### Branding
+
+Set via environment variable:
+- `FB_BRANDING_NAME` - Application title (default: `OADP VM File Restore Browser`)
+
+### TLS/SSL
+
+Automatically configured using OpenShift service serving certificates:
+- Service annotation `service.beta.openshift.io/serving-cert-secret-name: filebrowser-tls` triggers certificate generation
+- Container serves HTTPS on port 8443
+- Route uses `reencrypt` termination for end-to-end encryption
+
+### Permissions
+
+The deployment automatically creates a read-only user with locked settings:
+- ✅ View and download files
+- ❌ Create, delete, modify, rename, share, or execute
+
+All permissions are locked at container startup for security.
+
+## Deployment
+
+Complete sample deployment is available in `sample-deployment/`:
+
+- `1_namespace.yaml` - Namespace with privileged pod security
+- `2_secret.yaml` - Credentials (username/password)
+- `3_pvc.yaml` - PVC for backup data
+- `4_serving_pod.yaml` - Pod with init container, filebrowser, and service
+- `5_route.yaml` - OpenShift Route with reencrypt TLS
+
+### Required Volumes
+
+- **Backup data:** `/srv/restores` (mounted read-only from PVC)
+- **Database:** `/database` (emptyDir for user/settings)
+- **Tmp:** `/tmp` (emptyDir for read-only root filesystem)
+- **TLS certs:** `/etc/filebrowser-tls` (auto-generated secret)
+- **Credentials:** `/etc/filebrowser-credentials` (user-provided secret)
+
+### Security Context
+
+```yaml
+securityContext:
+  runAsUser: 1000
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+```
+
+## Security
+
+**Best Practices:**
+- Always use a strong password (minimum 12 characters)
+- Store credentials in Kubernetes Secrets
+- Mount backup volumes as `readOnly: true`
+- Use default HTTPS/TLS configuration
+- Review user permissions in logs after first startup
+
+## Comparison with SSHD
+
+| Feature | File Browser | SSHD |
+|---------|-------------|------|
+| Interface | Web UI | Command-line |
+| Authentication | Username/password | SSH keys |
+| Encryption | HTTPS (8443) | SSH (2222) |
+| Best For | Interactive browsing | Automation, bulk downloads |
+| Certificates | OpenShift service CA | N/A |
+
+Both can be deployed together in the same pod for multiple access methods.
+

--- a/side-containers/filebrowser/entrypoint.sh
+++ b/side-containers/filebrowser/entrypoint.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+set -e
+
+echo "==================================================================="
+echo "OADP VM File Restore File Browser Container Starting"
+echo "==================================================================="
+
+# Configuration from environment
+FB_DATABASE=${FB_DATABASE:-/database/filebrowser.db}
+FB_ROOT=${FB_ROOT:-/srv}
+FB_PORT=${FB_PORT:-8080}
+FB_ADDRESS=${FB_ADDRESS:-0.0.0.0}
+
+# Read credentials from secret
+if [ -f /etc/filebrowser-credentials/username ]; then
+    FB_USERNAME=$(cat /etc/filebrowser-credentials/username)
+else
+    FB_USERNAME="oadp"
+fi
+
+if [ -f /etc/filebrowser-credentials/password ]; then
+    FB_PASSWORD=$(cat /etc/filebrowser-credentials/password)
+else
+    echo "ERROR: Password not found in secret at /etc/filebrowser-credentials/password"
+    exit 1
+fi
+
+# Branding configuration
+FB_BRANDING_NAME=${FB_BRANDING_NAME:-OADP VM File Restore Browser}
+FB_BRANDING_FILES=${FB_BRANDING_FILES:-/branding}
+
+echo "Initializing File Browser..."
+
+# Initialize database if it doesn't exist
+if [ ! -f "${FB_DATABASE}" ]; then
+    echo "Creating new database at ${FB_DATABASE}..."
+    /usr/local/bin/filebrowser config init --database "${FB_DATABASE}"
+else
+    echo "Database exists at ${FB_DATABASE}"
+fi
+
+# Configure branding (idempotent - can run multiple times)
+echo "Configuring branding..."
+
+# Only set defaultLoginUser if username is missing or equals "oadp"
+if [ -z "${FB_USERNAME}" ] || [ "${FB_USERNAME}" = "oadp" ]; then
+    echo "Setting default login user to: oadp"
+    /usr/local/bin/filebrowser config set \
+      --database "${FB_DATABASE}" \
+      --branding.name "${FB_BRANDING_NAME}" \
+      --branding.disableUsedPercentage \
+      --branding.disableExternal \
+      --branding.disableUserProfile \
+      --branding.defaultLoginUser "oadp" \
+      --branding.files "${FB_BRANDING_FILES}"
+else
+    echo "Using custom username, not setting default login user"
+    /usr/local/bin/filebrowser config set \
+      --database "${FB_DATABASE}" \
+      --branding.name "${FB_BRANDING_NAME}" \
+      --branding.disableUsedPercentage \
+      --branding.disableExternal \
+      --branding.disableUserProfile \
+      --branding.files "${FB_BRANDING_FILES}"
+fi
+
+# Check if user exists, if not create it
+if /usr/local/bin/filebrowser users ls --database "${FB_DATABASE}" | grep -q "^| ${FB_USERNAME} "; then
+    echo "User ${FB_USERNAME} already exists"
+else
+    echo "Creating read-only user: ${FB_USERNAME}..."
+    /usr/local/bin/filebrowser users add "${FB_USERNAME}" "${FB_PASSWORD}" \
+      --database "${FB_DATABASE}" \
+      --perm.create=false \
+      --perm.delete=false \
+      --perm.modify=false \
+      --perm.rename=false \
+      --perm.share=false \
+      --perm.execute=false \
+      --lockPassword \
+      --locale en \
+      --hideDotfiles=false \
+      --singleClick=false \
+      --dateFormat=false
+    echo "User ${FB_USERNAME} created successfully"
+fi
+
+echo "==================================================================="
+echo "File Browser Configuration Complete"
+echo "==================================================================="
+echo "Service URL: http://${FB_ADDRESS}:${FB_PORT}"
+echo "Root Directory: ${FB_ROOT}"
+echo "Database: ${FB_DATABASE}"
+echo ""
+echo "User Credentials:"
+echo "  Username: ${FB_USERNAME}"
+echo "  Password: ${FB_PASSWORD}"
+echo ""
+echo "Permissions (Read-Only):"
+echo "  ✓ View files"
+echo "  ✓ Download files"
+echo "  ✗ Create/Upload"
+echo "  ✗ Delete"
+echo "  ✗ Modify"
+echo "  ✗ Rename"
+echo "  ✗ Share"
+echo "  ✗ Execute"
+echo ""
+echo "Branding: ${FB_BRANDING_NAME}"
+echo "==================================================================="
+
+# Start File Browser
+echo "Starting File Browser..."
+exec /usr/local/bin/filebrowser \
+  --address "${FB_ADDRESS}" \
+  --port "${FB_PORT}" \
+  --root "${FB_ROOT}" \
+  --database "${FB_DATABASE}"

--- a/side-containers/filebrowser/sample-deployment/1_namespace.yaml
+++ b/side-containers/filebrowser/sample-deployment/1_namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+  name: vmfr-pod-test

--- a/side-containers/filebrowser/sample-deployment/2_secret.yaml
+++ b/side-containers/filebrowser/sample-deployment/2_secret.yaml
@@ -1,0 +1,15 @@
+---
+# Secret with File Browser credentials
+# IMPORTANT: Change the password to a strong value in production!
+apiVersion: v1
+kind: Secret
+metadata:
+  name: filebrowser-credentials
+  namespace: vmfr-pod-test
+type: Opaque
+stringData:
+  # Username for File Browser login (optional, defaults to "oadp")
+  # username: oadp
+
+  # Password for File Browser login (minimum 12 characters required)
+  password: oadppassword

--- a/side-containers/filebrowser/sample-deployment/3_pvc.yaml
+++ b/side-containers/filebrowser/sample-deployment/3_pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: restores-pvc
+  namespace: vmfr-pod-test
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  # storageClassName: <your-storage-class>  # Uncomment and specify if needed

--- a/side-containers/filebrowser/sample-deployment/4_serving_pod.yaml
+++ b/side-containers/filebrowser/sample-deployment/4_serving_pod.yaml
@@ -1,0 +1,285 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: file-serving-pod
+  namespace: vmfr-pod-test
+  labels:
+    app: file-serving-pod
+spec:
+  # Pod-level security context to set fsGroup for volume ownership
+  securityContext:
+    fsGroup: 1000  # Files created in emptyDir volumes will be owned by GID 1000
+
+  initContainers:
+  # Privileged init container to create sample data
+  - name: setup-data
+    image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -ex
+        # File Browser user will have UID 1000
+        FB_UID=1000
+        FB_GID=1000
+
+        # Create sample directory structure
+        mkdir -p /restores/sampledata/vm1/disk1
+        mkdir -p /restores/sampledata/vm1/disk2
+        mkdir -p /restores/sampledata/vm2/disk1
+
+        # Create some sample files
+        echo "Sample data for VM1 disk1" > /restores/sampledata/vm1/disk1/data.txt
+        echo "Sample data for VM1 disk2" > /restores/sampledata/vm1/disk2/data.txt
+        echo "Sample data for VM2 disk1" > /restores/sampledata/vm2/disk1/data.txt
+
+        # Create a README
+        {
+          echo "OADP VM File Restore - Sample Data"
+          echo ""
+          echo "This directory contains sample backup data."
+          echo "In production, this would be restored from Velero backups."
+          echo ""
+          echo "Access via File Browser:"
+          echo "- Browse files through web interface"
+          echo "- Download individual files"
+          echo "- Download directories as ZIP archives"
+          echo "- Preview supported file types"
+        } > /restores/sampledata/README.txt
+
+        # Set ownership to filebrowser user (UID 1000)
+        chown -R ${FB_UID}:${FB_GID} /restores/sampledata
+
+        # Set permissions to allow filebrowser user full access
+        chmod -R 755 /restores/sampledata
+
+        echo "Sample data setup complete - owned by UID ${FB_UID}"
+        ls -lan /restores/sampledata/
+    volumeMounts:
+    - name: restores-volume
+      mountPath: /restores
+    securityContext:
+      privileged: true
+      runAsUser: 0
+
+  containers:
+  # File Browser container - provides web-based file access
+  - name: filebrowser
+    image: quay.io/migtools/oadp-vmfr-filebrowser:latest
+    command:
+      - /bin/bash
+      - -c
+      - |
+        set -e
+
+        echo "==================================================================="
+        echo "OADP VM File Restore File Browser Container Starting"
+        echo "==================================================================="
+
+        # Configuration from environment
+        FB_DATABASE=${FB_DATABASE:-/database/filebrowser.db}
+        FB_ROOT=${FB_ROOT:-/srv}
+        FB_PORT=${FB_PORT:-8080}
+        FB_ADDRESS=${FB_ADDRESS:-0.0.0.0}
+
+        # Read credentials from secret
+        if [ -f /etc/filebrowser-credentials/username ]; then
+            FB_USERNAME=$(cat /etc/filebrowser-credentials/username)
+        else
+            FB_USERNAME="oadp"
+        fi
+
+        if [ -f /etc/filebrowser-credentials/password ]; then
+            FB_PASSWORD=$(cat /etc/filebrowser-credentials/password)
+        else
+            echo "ERROR: Password not found in secret at /etc/filebrowser-credentials/password"
+            exit 1
+        fi
+
+        # Branding configuration
+        FB_BRANDING_NAME=${FB_BRANDING_NAME:-OADP VM File Restore Browser}
+
+        echo "Initializing File Browser..."
+
+        # Initialize database if it doesn't exist
+        if [ ! -f "${FB_DATABASE}" ]; then
+            echo "Creating new database at ${FB_DATABASE}..."
+            /usr/local/bin/filebrowser config init --database "${FB_DATABASE}"
+        else
+            echo "Database exists at ${FB_DATABASE}"
+        fi
+
+        # Configure branding (idempotent - can run multiple times)
+        echo "Configuring branding..."
+
+        # Only set defaultLoginUser if username is missing or equals "oadp"
+        if [ -z "${FB_USERNAME}" ] || [ "${FB_USERNAME}" = "oadp" ]; then
+            echo "Setting default login user to: oadp"
+            /usr/local/bin/filebrowser config set \
+              --database "${FB_DATABASE}" \
+              --branding.name "${FB_BRANDING_NAME}" \
+              --branding.disableUsedPercentage \
+              --branding.disableExternal \
+              --branding.disableUserProfile \
+              --branding.defaultLoginUser "oadp"
+        else
+            echo "Using custom username, not setting default login user"
+            /usr/local/bin/filebrowser config set \
+              --database "${FB_DATABASE}" \
+              --branding.name "${FB_BRANDING_NAME}" \
+              --branding.disableUsedPercentage \
+              --branding.disableExternal \
+              --branding.disableUserProfile
+        fi
+
+        # Check if user exists, if not create it
+        if /usr/local/bin/filebrowser users ls --database "${FB_DATABASE}" | grep -q "^| ${FB_USERNAME} "; then
+            echo "User ${FB_USERNAME} already exists"
+        else
+            echo "Creating read-only user: ${FB_USERNAME}..."
+            /usr/local/bin/filebrowser users add "${FB_USERNAME}" "${FB_PASSWORD}" \
+              --database "${FB_DATABASE}" \
+              --perm.create=false \
+              --perm.delete=false \
+              --perm.modify=false \
+              --perm.rename=false \
+              --perm.share=false \
+              --perm.execute=false \
+              --lockPassword \
+              --locale en \
+              --hideDotfiles=false \
+              --singleClick=false \
+              --dateFormat=false
+            echo "User ${FB_USERNAME} created successfully"
+        fi
+
+        echo "==================================================================="
+        echo "File Browser Configuration Complete"
+        echo "==================================================================="
+        echo "Service URL: http://${FB_ADDRESS}:${FB_PORT}"
+        echo "Root Directory: ${FB_ROOT}"
+        echo ""
+        echo "User Credentials:"
+        echo "  Username: ${FB_USERNAME}"
+        echo "  Password: ********"
+        echo ""
+        echo "Permissions (Read-Only):"
+        echo "  ✓ View files"
+        echo "  ✓ Download files"
+        echo "  ✗ Create/Upload"
+        echo "  ✗ Delete/Modify/Rename/Share/Execute"
+        echo ""
+        echo "Branding: ${FB_BRANDING_NAME}"
+        echo "==================================================================="
+
+        # Start File Browser with TLS
+        echo "Starting File Browser with HTTPS..."
+        if [ -f /etc/filebrowser-tls/tls.crt ] && [ -f /etc/filebrowser-tls/tls.key ]; then
+          echo "TLS certificates found, starting with HTTPS on port ${FB_PORT}"
+          exec /usr/local/bin/filebrowser \
+            --address "${FB_ADDRESS}" \
+            --port "${FB_PORT}" \
+            --root "${FB_ROOT}" \
+            --database "${FB_DATABASE}" \
+            --cert /etc/filebrowser-tls/tls.crt \
+            --key /etc/filebrowser-tls/tls.key
+        else
+          echo "WARNING: TLS certificates not found, starting with HTTP"
+          exec /usr/local/bin/filebrowser \
+            --address "${FB_ADDRESS}" \
+            --port "${FB_PORT}" \
+            --root "${FB_ROOT}" \
+            --database "${FB_DATABASE}"
+        fi
+    ports:
+    - containerPort: 8443
+      name: https
+      protocol: TCP
+    env:
+    # File Browser configuration
+    - name: FB_ROOT
+      value: "/srv/restores"
+    - name: FB_PORT
+      value: "8443"
+    - name: FB_ADDRESS
+      value: "0.0.0.0"
+    - name: FB_DATABASE
+      value: "/database/filebrowser.db"
+    # Branding
+    - name: FB_BRANDING_NAME
+      value: "OADP VM File Restore Browser"
+    volumeMounts:
+    - name: restores-volume
+      mountPath: /srv/restores
+      readOnly: true  # Read-only access for security
+    - name: database
+      mountPath: /database
+    - name: tmp
+      mountPath: /tmp
+    - name: filebrowser-tls
+      mountPath: /etc/filebrowser-tls
+      readOnly: true
+    - name: filebrowser-credentials
+      mountPath: /etc/filebrowser-credentials
+      readOnly: true
+    securityContext:
+      # File Browser runs as non-root
+      runAsUser: 1000
+      runAsGroup: 1000
+      runAsNonRoot: true
+      # Read-only root filesystem for additional security
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      # Minimal capabilities
+      capabilities:
+        drop:
+        - ALL
+
+  volumes:
+  - name: restores-volume
+    persistentVolumeClaim:
+      claimName: restores-pvc
+  # Database volume for File Browser state
+  - name: database
+    emptyDir:
+      medium: Memory
+      sizeLimit: 10Mi
+  # Tmp volume for read-only root filesystem
+  - name: tmp
+    emptyDir:
+      medium: Memory
+      sizeLimit: 10Mi
+  # TLS certificates from OpenShift service CA
+  - name: filebrowser-tls
+    secret:
+      secretName: filebrowser-tls
+      defaultMode: 0400
+  # User credentials from secret
+  - name: filebrowser-credentials
+    secret:
+      secretName: filebrowser-credentials
+      defaultMode: 0400
+
+  restartPolicy: Always
+---
+# Service to expose HTTPS port
+apiVersion: v1
+kind: Service
+metadata:
+  name: file-serving-http
+  namespace: vmfr-pod-test
+  labels:
+    app: file-serving-pod
+  annotations:
+    # Request OpenShift to generate a serving certificate
+    service.beta.openshift.io/serving-cert-secret-name: filebrowser-tls
+spec:
+  selector:
+    app: file-serving-pod
+  type: ClusterIP
+  ports:
+  - name: https
+    port: 8443
+    targetPort: 8443
+    protocol: TCP

--- a/side-containers/filebrowser/sample-deployment/5_route.yaml
+++ b/side-containers/filebrowser/sample-deployment/5_route.yaml
@@ -1,0 +1,20 @@
+---
+# OpenShift Route for external HTTPS access
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: file-serving-http
+  namespace: vmfr-pod-test
+  labels:
+    app: file-serving-pod
+spec:
+  to:
+    kind: Service
+    name: file-serving-http
+    weight: 100
+  port:
+    targetPort: https
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None


### PR DESCRIPTION
Add filebrowser side-container for web-based file access

Introduces web UI alternative to SSHD for browsing VM backup files.

Includes HTTPS/TLS support, read-only permissions, and OpenShift
service CA integration.

The container itself is being built from github.com/migtools/filebrowser repository.