### PR TITLE
Add Block mode PVC support, dual-path directory structure, DataDownload auto-fix, and privileged SCC for VM disk mounting

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	velerov2alpha1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
 	uberzap "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -58,6 +59,7 @@ func init() {
 
 	utilruntime.Must(oadpv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(velerov1api.AddToScheme(scheme))
+	utilruntime.Must(velerov2alpha1api.AddToScheme(scheme))
 	utilruntime.Must(kubevirtv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: oadp-vm-file-restore-system
+namespace: openshift-adp
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/mpryc/oadp-vm-file-restore
-  newTag: latest
+  newName: quay.io/spampatt/oadp-vm-file-restore
+  newTag: dev

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/spampatt/oadp-vm-file-restore
-  newTag: dev
+  newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,7 +64,13 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
         image: controller:latest
+        imagePullPolicy: Always
         name: manager
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports: []
         securityContext:
           readOnlyRootFilesystem: true

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -92,6 +92,15 @@ rules:
 - apiGroups:
   - velero.io
   resources:
+  - datadownloads
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - velero.io
+  resources:
   - downloadrequests
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,6 +10,7 @@ rules:
   - namespaces
   - pods
   - secrets
+  - serviceaccounts
   - services
   verbs:
   - create
@@ -69,10 +70,32 @@ rules:
   - patch
   - update
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - velero.io
   resources:
   - backups
   verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - velero.io
+  resources:
+  - downloadrequests
+  verbs:
+  - create
+  - delete
   - get
   - list
   - watch

--- a/containers/file-server/scripts/detect-and-mount.sh
+++ b/containers/file-server/scripts/detect-and-mount.sh
@@ -303,12 +303,20 @@ PYEOF
 
         # Find disk image in the PVC path (can be regular file or block device)
         local disk_image=""
-        for ext in img raw qcow2 qcow vmdk vdi; do
-            if [ -f "$pvc_path/disk.$ext" ] || [ -b "$pvc_path/disk.$ext" ]; then
-                disk_image="$pvc_path/disk.$ext"
-                break
-            fi
-        done
+
+        # Check if pvc_path itself is a block device (Block mode PVC)
+        if [ -b "$pvc_path" ]; then
+            disk_image="$pvc_path"
+            log "Found block device (Block mode PVC): $disk_image"
+        else
+            # Filesystem mode PVC: look for disk image files
+            for ext in img raw qcow2 qcow vmdk vdi; do
+                if [ -f "$pvc_path/disk.$ext" ]; then
+                    disk_image="$pvc_path/disk.$ext"
+                    break
+                fi
+            done
+        fi
 
         if [ -z "$disk_image" ]; then
             error "No disk image found in $pvc_path"
@@ -344,6 +352,9 @@ PYEOF
 
     # Generate METADATA.json
     generate_metadata
+
+    # Create dual-path directory structure for SSH browsing
+    create_dual_path_structure
 
     return 0
 }
@@ -422,30 +433,28 @@ PYEOF
 # processes each found disk image. This is the default mode when the
 # script is run without arguments.
 #
-# Supported extensions:
-#   - .qcow2 (most common for KubeVirt/QEMU)
-#   - .raw
-#   - .img
-#   - .qcow
-#   - .vmdk (VMware, less common but supported)
-#   - .vdi (VirtualBox)
+# Supported sources:
+#   - Filesystem mode PVCs: Files in VOLUME_MOUNT_DIR with extensions:
+#     .qcow2 (most common for KubeVirt/QEMU), .raw, .img, .qcow, .vmdk, .vdi
+#   - Block mode PVCs: Block devices at /dev/pvc-* (VM disks as raw block devices)
 #
 # Returns:
 #   Always returns 0 (does not fail if no disks found or some fail to mount)
 auto_mount_all() {
-    log "Auto-mounting all disk images in $VOLUME_MOUNT_DIR"
+    log "Auto-mounting all disk images in $VOLUME_MOUNT_DIR and Block devices at /dev/pvc-*"
 
     local found=false
     local success_count=0
     local fail_count=0
 
+    # Part 1: Scan for Filesystem mode PVCs (disk image files)
     # Look for common VM disk image file extensions
     # Bash brace expansion: expands to multiple patterns
     for disk in "$VOLUME_MOUNT_DIR"/*.{qcow2,raw,img,qcow,vmdk,vdi}; do
         # Check if file actually exists (glob may not match anything)
         if [[ -f "$disk" ]]; then
             found=true
-            log "Found disk image: $disk"
+            log "Found disk image file: $disk"
 
             # Process each disk, but don't fail on individual errors
             if process_disk_image "$disk"; then
@@ -457,9 +466,34 @@ auto_mount_all() {
         fi
     done
 
+    # Part 2: Scan for Block mode PVCs (block devices at /dev/pvc-*)
+    # Block devices are created by Kubernetes when volumeMode: Block is used
+    log "Scanning for Block mode PVC devices at /dev/pvc-*"
+    for block_device in /dev/pvc-*; do
+        # Check if block device actually exists (glob may not match anything)
+        if [[ -b "$block_device" ]]; then
+            found=true
+            log "Found Block mode PVC device: $block_device"
+
+            # Extract PVC UID from device name: /dev/pvc-{uid} -> {uid}
+            local pvc_uid="${block_device#/dev/pvc-}"
+            local volume_name="pvc-$pvc_uid"
+
+            # Process block device as disk image
+            # process_disk_image already handles both files and block devices (see line 91: [[ ! -b "$disk_path" ]])
+            if process_disk_image "$block_device" "$volume_name"; then
+                ((success_count++))
+            else
+                ((fail_count++))
+                log "Warning: Failed to process Block device $block_device, continuing with remaining devices"
+            fi
+        fi
+    done
+
     if [[ "$found" == "false" ]]; then
-        log "No disk images found in $VOLUME_MOUNT_DIR"
-        log "Supported extensions: .qcow2, .raw, .img, .qcow, .vmdk, .vdi"
+        log "No disk images or Block devices found"
+        log "Filesystem mode PVCs: Searched in $VOLUME_MOUNT_DIR for .qcow2, .raw, .img, .qcow, .vmdk, .vdi"
+        log "Block mode PVCs: Searched for /dev/pvc-* devices"
     else
         log "Auto-mount completed: $success_count successful, $fail_count failed"
     fi
@@ -467,6 +501,119 @@ auto_mount_all() {
     # List mounted filesystems
     log "Currently mounted filesystems:"
     mount | grep "$FS_MOUNT_DIR" || true
+
+    # Create dual-path directory structure for SSH browsing
+    create_dual_path_structure
+}
+
+# create_dual_path_structure - Create /restores_by_name and /restores_by_date directory structure
+#
+# This function creates a dual-path symlink structure for browsing restored filesystems:
+#   1. /restores_by_name/<backup-name>/<pvc-uid> -> /mnt/filesystems/pvc-<pvc-uid>/
+#   2. /restores_by_date/<date>/<pvc-name> -> /restores_by_name/<backup-name>/<pvc-uid>
+#
+# Requires BACKUP_PVC_MAP environment variable with backup metadata in JSON format:
+#   {"backup-name": [{"name": "pvc-name", "path": "/dev/pvc-{uid}", "timestamp": "2025-10-23T18:40:00Z"}]}
+#
+# Returns:
+#   Exit code 0 on success
+create_dual_path_structure() {
+    local restores_by_name="/restores_by_name"
+    local restores_by_date="/restores_by_date"
+
+    # Check if BACKUP_PVC_MAP is available
+    if [[ -z "$BACKUP_PVC_MAP" ]]; then
+        log "BACKUP_PVC_MAP not set, skipping dual-path structure creation"
+        return 0
+    fi
+
+    log "Creating dual-path directory structure for SSH browsing"
+
+    # Create base directories
+    mkdir -p "$restores_by_name" "$restores_by_date"
+
+    # Parse BACKUP_PVC_MAP using Python
+    python3 <<'PYEOF' | while IFS='|' read -r backup_name pvc_name pvc_uid backup_date; do
+import json, os, sys
+from datetime import datetime
+
+try:
+    backup_map = json.loads(os.environ.get('BACKUP_PVC_MAP', '{}'))
+    for backup_name, pvcs in backup_map.items():
+        for pvc in pvcs:
+            # Extract PVC UID from path
+            pvc_path = pvc.get('path', '')
+            if '/dev/pvc-' in pvc_path:
+                pvc_uid = pvc_path.split('/dev/pvc-')[-1]
+            elif pvc_path.startswith('pvc-'):
+                pvc_uid = pvc_path[4:]
+            else:
+                # Fallback: use last component of path
+                pvc_uid = pvc_path.rstrip('/').split('/')[-1]
+                if pvc_uid.startswith('pvc-'):
+                    pvc_uid = pvc_uid[4:]
+
+            # Format backup timestamp as YYYY-MM-DD
+            backup_timestamp = pvc.get('timestamp', '')
+            if backup_timestamp:
+                try:
+                    dt = datetime.fromisoformat(backup_timestamp.replace('Z', '+00:00'))
+                    backup_date = dt.strftime('%Y-%m-%d')
+                except:
+                    backup_date = datetime.now().strftime('%Y-%m-%d')
+            else:
+                backup_date = datetime.now().strftime('%Y-%m-%d')
+
+            print(f"{backup_name}|{pvc.get('name', 'unknown')}|{pvc_uid}|{backup_date}")
+except Exception as e:
+    print(f"ERROR: Failed to parse BACKUP_PVC_MAP: {e}", file=sys.stderr)
+    sys.exit(1)
+PYEOF
+
+        # Skip if parsing failed
+        if [[ -z "$backup_name" ]] || [[ -z "$pvc_uid" ]]; then
+            continue
+        fi
+
+        # Source mount is at /mnt/filesystems/{backup-name}/{pvc-name}/
+        local source_mount="$FS_MOUNT_DIR/$backup_name/$pvc_name"
+
+        # Check if source mount exists
+        if [[ ! -d "$source_mount" ]]; then
+            log "Warning: Source mount $source_mount does not exist, skipping"
+            continue
+        fi
+
+        # Create /restores_by_name/<backup-name>/<pvc-name> -> /mnt/filesystems/{backup-name}/{pvc-name}/
+        local backup_dir="$restores_by_name/$backup_name"
+        local name_symlink="$backup_dir/$pvc_name"
+
+        if [[ ! -d "$backup_dir" ]]; then
+            mkdir -p "$backup_dir"
+            log "Created directory: $backup_dir"
+        fi
+
+        if [[ ! -e "$name_symlink" ]]; then
+            ln -sf "$source_mount" "$name_symlink"
+            log "Created symlink: $name_symlink -> $source_mount"
+        fi
+
+        # Create /restores_by_date/<date>/<pvc-name> -> /restores_by_name/<backup-name>/<pvc-uid>
+        local date_dir="$restores_by_date/$backup_date"
+        local date_symlink="$date_dir/$pvc_name"
+
+        if [[ ! -d "$date_dir" ]]; then
+            mkdir -p "$date_dir"
+            log "Created directory: $date_dir"
+        fi
+
+        if [[ ! -e "$date_symlink" ]]; then
+            ln -sf "$name_symlink" "$date_symlink"
+            log "Created symlink: $date_symlink -> $name_symlink"
+        fi
+    done
+
+    log "Completed dual-path directory structure creation"
 }
 
 # main - Entry point for the script

--- a/internal/common/constant/constant.go
+++ b/internal/common/constant/constant.go
@@ -137,7 +137,7 @@ const (
 	FileServerServicePrefix  = "vmfr-service"
 
 	// VM file server container image for mounting VM disk images
-	VMFileServerImage = "quay.io/spampatt/oadp-vm-file-server:dev"
+	VMFileServerImage = "quay.io/spampatt/oadp-vm-file-server:dual-path-fix"
 
 	// Default ports for file access methods
 	DefaultSSHPort         = 22

--- a/internal/common/function/function.go
+++ b/internal/common/function/function.go
@@ -282,19 +282,37 @@ func CreateSSHCredentialsSecret(
 	vmfrUID apitypes.UID,
 	logger logr.Logger,
 ) *corev1.Secret {
-	secret := createCredentialsSecretBase(
-		generateNamePrefix,
-		namespace,
-		constant.CredentialTypeSSH,
-		vmfrName,
-		vmfrNamespace,
-		vmfrUID,
-	)
-
-	secret.StringData = map[string]string{
-		"username":   username,
-		"privateKey": keyPair.PrivateKey,
-		"publicKey":  keyPair.PublicKey,
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				constant.ManagedByLabel:             constant.ManagedByLabelValue,
+				constant.VMFROriginUUIDLabel:        string(vmfrUID),
+				"oadp.openshift.io/credential-type": "ssh",
+			},
+			Annotations: map[string]string{
+				constant.VMFROriginNameAnnotation:      vmfrName,
+				constant.VMFROriginNamespaceAnnotation: vmfrNamespace,
+				"oadp.openshift.io/generated-by":       "oadp-vm-file-restore-controller",
+			},
+			// IMPORTANT: Do NOT add cross-namespace owner references!
+			// Kubernetes does not allow owner references where the owner is in a different
+			// namespace than the owned resource (VMFR is in openshift-adp, secret is in
+			// temporary restore namespace). Cross-namespace owner references are rejected
+			// by Kubernetes admission controller, causing silent failures.
+			//
+			// Instead, we use:
+			// 1. Labels to track ownership (VMFROriginUUIDLabel already added above)
+			// 2. The temporary namespace has an owner reference to VMFR
+			// 3. When VMFR is deleted, the namespace is deleted, cascading to all resources
+		},
+		Type: corev1.SecretTypeOpaque,
+		StringData: map[string]string{
+			"username":   username,
+			"privateKey": keyPair.PrivateKey,
+			"publicKey":  keyPair.PublicKey,
+		},
 	}
 
 	logger.V(1).Info("Created SSH credentials secret with generateName",
@@ -320,18 +338,36 @@ func CreateFileBrowserCredentialsSecret(
 	vmfrUID apitypes.UID,
 	logger logr.Logger,
 ) *corev1.Secret {
-	secret := createCredentialsSecretBase(
-		generateNamePrefix,
-		namespace,
-		constant.CredentialTypeFileBrowser,
-		vmfrName,
-		vmfrNamespace,
-		vmfrUID,
-	)
-
-	secret.StringData = map[string]string{
-		"username": credentials.Username,
-		"password": credentials.Password,
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				constant.ManagedByLabel:             constant.ManagedByLabelValue,
+				constant.VMFROriginUUIDLabel:        string(vmfrUID),
+				"oadp.openshift.io/credential-type": "filebrowser",
+			},
+			Annotations: map[string]string{
+				constant.VMFROriginNameAnnotation:      vmfrName,
+				constant.VMFROriginNamespaceAnnotation: vmfrNamespace,
+				"oadp.openshift.io/generated-by":       "oadp-vm-file-restore-controller",
+			},
+			// IMPORTANT: Do NOT add cross-namespace owner references!
+			// Kubernetes does not allow owner references where the owner is in a different
+			// namespace than the owned resource (VMFR is in openshift-adp, secret is in
+			// temporary restore namespace). Cross-namespace owner references are rejected
+			// by Kubernetes admission controller, causing silent failures.
+			//
+			// Instead, we use:
+			// 1. Labels to track ownership (VMFROriginUUIDLabel already added above)
+			// 2. The temporary namespace has an owner reference to VMFR
+			// 3. When VMFR is deleted, the namespace is deleted, cascading to all resources
+		},
+		Type: corev1.SecretTypeOpaque,
+		StringData: map[string]string{
+			"username": credentials.Username,
+			"password": credentials.Password,
+		},
 	}
 
 	logger.V(1).Info("Created FileBrowser credentials secret with generateName",

--- a/internal/common/function/function.go
+++ b/internal/common/function/function.go
@@ -284,8 +284,8 @@ func CreateSSHCredentialsSecret(
 ) *corev1.Secret {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			GenerateName: generateNamePrefix,
+			Namespace:    namespace,
 			Labels: map[string]string{
 				constant.ManagedByLabel:             constant.ManagedByLabelValue,
 				constant.VMFROriginUUIDLabel:        string(vmfrUID),
@@ -340,8 +340,8 @@ func CreateFileBrowserCredentialsSecret(
 ) *corev1.Secret {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			GenerateName: generateNamePrefix,
+			Namespace:    namespace,
 			Labels: map[string]string{
 				constant.ManagedByLabel:             constant.ManagedByLabelValue,
 				constant.VMFROriginUUIDLabel:        string(vmfrUID),

--- a/internal/controller/fileserver_helpers.go
+++ b/internal/controller/fileserver_helpers.go
@@ -40,8 +40,9 @@ type PVCMountInfo struct {
 	PVCUID            string
 	BackupName        string
 	BackupTimestamp   *metav1.Time
-	VeleroRestoreName string // Name of the Velero Restore CR that restored this PVC
-	RestoredPVCName   string // Actual name of the restored PVC (may differ from original)
+	VeleroRestoreName string                       // Name of the Velero Restore CR that restored this PVC
+	RestoredPVCName   string                       // Actual name of the restored PVC (may differ from original)
+	VolumeMode        *corev1.PersistentVolumeMode // VolumeMode of the PVC (Block or Filesystem), nil if not yet queried
 }
 
 // SSHAccessConfig contains configuration for SSH sidecar container
@@ -229,8 +230,9 @@ func buildFileServerPodSpec(config FileServerPodConfig) (*corev1.Pod, error) {
 		config.SharedMountPath = "/mnt/restore"
 	}
 
-	// Build PVC volumes (always added to pod, even in internal mount mode)
-	pvcVolumes, pvcVolumeMounts := buildPVCVolumesAndMounts(config.PVCMounts)
+	// Build PVC volumes, mounts, and devices (always added to pod, even in internal mount mode)
+	// Returns volumeMounts for Filesystem PVCs and volumeDevices for Block mode PVCs
+	pvcVolumes, pvcVolumeMounts, pvcVolumeDevices := buildPVCVolumesAndMounts(config.PVCMounts)
 
 	// Collect all volumes: PVC volumes + sidecar volumes (SSH, FileBrowser) + utility volumes
 	allVolumes := make([]corev1.Volume, 0, len(pvcVolumes)+10)
@@ -366,8 +368,9 @@ func buildFileServerPodSpec(config FileServerPodConfig) (*corev1.Pod, error) {
 		}
 	} else {
 		// Kubernetes-managed mode: kubelet handles PVC mounting
-		// Inject PVC volume mounts into the main container
+		// Inject PVC volume mounts (Filesystem mode) and volume devices (Block mode) into the main container
 		mainContainer.VolumeMounts = append(mainContainer.VolumeMounts, pvcVolumeMounts...)
+		mainContainer.VolumeDevices = append(mainContainer.VolumeDevices, pvcVolumeDevices...)
 
 		// If dual-path is enabled, also mount the symlink directory
 		if config.EnableDualPathAccess {
@@ -516,10 +519,19 @@ func buildFileServerDeployment(config FileServerPodConfig) (*appsv1.Deployment, 
 	return deployment, nil
 }
 
-// buildPVCVolumesAndMounts creates volumes and volume mounts for PVCs
-func buildPVCVolumesAndMounts(pvcMounts []PVCMountInfo) ([]corev1.Volume, []corev1.VolumeMount) {
+// buildPVCVolumesAndMounts creates volumes, volume mounts, and volume devices for PVCs.
+// Handles both Block and Filesystem mode PVCs correctly:
+// - Block mode PVCs: VM disks stored as raw block devices, exposed via volumeDevices at /dev/pvc-{uid}
+// - Filesystem mode PVCs: Traditional file storage, mounted via volumeMounts at /restores_by_name/{backup}/{uid}
+//
+// Returns:
+// - volumes: Kubernetes Volume objects referencing the PVCs
+// - volumeMounts: Mount points for Filesystem mode PVCs
+// - volumeDevices: Device mappings for Block mode PVCs
+func buildPVCVolumesAndMounts(pvcMounts []PVCMountInfo) ([]corev1.Volume, []corev1.VolumeMount, []corev1.VolumeDevice) {
 	volumes := make([]corev1.Volume, 0, len(pvcMounts))
 	volumeMounts := make([]corev1.VolumeMount, 0, len(pvcMounts))
+	volumeDevices := make([]corev1.VolumeDevice, 0, len(pvcMounts))
 
 	for _, pvcMount := range pvcMounts {
 		// Create unique volume name for this PVC
@@ -532,27 +544,42 @@ func buildPVCVolumesAndMounts(pvcMounts []PVCMountInfo) ([]corev1.Volume, []core
 			pvcClaimName = pvcMount.PVCName
 		}
 
-		// Add volume referencing the restored PVC
+		// Add volume referencing the restored PVC (always added regardless of mode)
 		volumes = append(volumes, corev1.Volume{
 			Name: volumeName,
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 					ClaimName: pvcClaimName,
-					ReadOnly:  true, // Mount read-only for safety
+					ReadOnly:  false, // libguestfs needs write access for internal operations
 				},
 			},
 		})
 
-		// Mount path: /restores_by_name/<backup-name>/<pvc-uid>
-		mountPath := fmt.Sprintf("/restores_by_name/%s/%s", pvcMount.BackupName, pvcMount.PVCUID)
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      volumeName,
-			MountPath: mountPath,
-			ReadOnly:  true,
-		})
+		// Determine how to expose the PVC based on its volumeMode
+		// Default to Filesystem if volumeMode is nil (Kubernetes default)
+		isBlockMode := pvcMount.VolumeMode != nil && *pvcMount.VolumeMode == corev1.PersistentVolumeBlock
+
+		if isBlockMode {
+			// Block mode: Expose as raw block device at /dev/pvc-{uid}
+			// libguestfs/QEMU can directly access the block device containing the VM disk image
+			devicePath := fmt.Sprintf("/dev/pvc-%s", pvcMount.PVCUID)
+			volumeDevices = append(volumeDevices, corev1.VolumeDevice{
+				Name:       volumeName,
+				DevicePath: devicePath,
+			})
+		} else {
+			// Filesystem mode: Mount at /restores_by_name/<backup-name>/<pvc-uid>
+			// Traditional file access for filesystem-based storage
+			mountPath := fmt.Sprintf("/restores_by_name/%s/%s", pvcMount.BackupName, pvcMount.PVCUID)
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      volumeName,
+				MountPath: mountPath,
+				ReadOnly:  false, // libguestfs needs write access
+			})
+		}
 	}
 
-	return volumes, volumeMounts
+	return volumes, volumeMounts, volumeDevices
 }
 
 // buildDefaultMainContainer creates a default busybox HTTP server container
@@ -610,7 +637,7 @@ func buildVMFileServerMainContainer() corev1.Container {
 		// Container-level security context
 		// CRITICAL: Privileged mode required for /dev/kvm access with SELinux
 		SecurityContext: &corev1.SecurityContext{
-			Privileged: ptr.To(true), // Required for /dev/kvm and /dev/fuse access
+			Privileged: ptr.To(true),       // Required for /dev/kvm and /dev/fuse access
 			RunAsUser:  ptr.To(int64(107)), // qemu user
 			RunAsGroup: ptr.To(int64(107)), // qemu group
 		},
@@ -622,7 +649,7 @@ func buildVMFileServerMainContainer() corev1.Container {
 				corev1.ResourceCPU:    resource.MustParse("250m"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("2Gi"),  // libguestfs can use significant memory
+				corev1.ResourceMemory: resource.MustParse("2Gi"),   // libguestfs can use significant memory
 				corev1.ResourceCPU:    resource.MustParse("1000m"), // KVM uses CPU during mount
 			},
 		},

--- a/internal/controller/fileserver_helpers.go
+++ b/internal/controller/fileserver_helpers.go
@@ -23,8 +23,8 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
@@ -258,6 +258,36 @@ func buildFileServerPodSpec(config FileServerPodConfig) (*corev1.Pod, error) {
 		})
 	}
 
+	// Add /dev/fuse hostPath volume (required for guestmount FUSE filesystem)
+	allVolumes = append(allVolumes, corev1.Volume{
+		Name: "fuse-device",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/dev/fuse",
+				Type: ptr.To(corev1.HostPathCharDev),
+			},
+		},
+	})
+
+	// Add /dev/kvm hostPath volume (required for KVM hardware acceleration)
+	allVolumes = append(allVolumes, corev1.Volume{
+		Name: "kvm-device",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/dev/kvm",
+				Type: ptr.To(corev1.HostPathCharDev),
+			},
+		},
+	})
+
+	// Add emptyDir for filesystem mount points (where guestmount will mount filesystems)
+	allVolumes = append(allVolumes, corev1.Volume{
+		Name: "filesystems",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	})
+
 	// Collect init containers and sidecar containers
 	var allInitContainers []corev1.Container
 	var sidecarContainers []corev1.Container
@@ -347,6 +377,24 @@ func buildFileServerPodSpec(config FileServerPodConfig) (*corev1.Pod, error) {
 				ReadOnly:  true,
 			})
 		}
+
+		// Add /dev/fuse device mount (required for guestmount)
+		mainContainer.VolumeMounts = append(mainContainer.VolumeMounts, corev1.VolumeMount{
+			Name:      "fuse-device",
+			MountPath: "/dev/fuse",
+		})
+
+		// Add /dev/kvm device mount (required for KVM acceleration)
+		mainContainer.VolumeMounts = append(mainContainer.VolumeMounts, corev1.VolumeMount{
+			Name:      "kvm-device",
+			MountPath: "/dev/kvm",
+		})
+
+		// Add filesystems mount point (where guestmount will create filesystem mounts)
+		mainContainer.VolumeMounts = append(mainContainer.VolumeMounts, corev1.VolumeMount{
+			Name:      "filesystems",
+			MountPath: "/mnt/filesystems",
+		})
 	}
 
 	// Combine main container with sidecars
@@ -366,26 +414,39 @@ func buildFileServerPodSpec(config FileServerPodConfig) (*corev1.Pod, error) {
 			Annotations: annotations,
 		},
 		Spec: corev1.PodSpec{
-			InitContainers: allInitContainers,
-			Containers:     containers,
-			Volumes:        allVolumes,
-			RestartPolicy:  corev1.RestartPolicyAlways,
+			// Use dedicated ServiceAccount for file server pods
+			// This ServiceAccount is created by the controller in ensureRestoreNamespace
+			// and is bound to the privileged SCC to allow hostPath volumes and privileged containers
+			ServiceAccountName: "vmfr-file-server",
+			InitContainers:     allInitContainers,
+			Containers:         containers,
+			Volumes:            allVolumes,
+			RestartPolicy:      corev1.RestartPolicyAlways,
+			// Pod-level security context
+			// Required for accessing VM disk images with qemu user/group permissions
+			SecurityContext: &corev1.PodSecurityContext{
+				// fsGroup: 107 (qemu group in OpenShift Virtualization)
+				// This ensures volumes are accessible by the qemu user/group
+				FSGroup: ptr.To(int64(107)),
+				// supplementalGroups: [107] - Grants qemu group membership to all containers
+				SupplementalGroups: []int64{107},
+				// SELinux: Use spc_t (Super Privileged Container) type
+				// This disables SELinux enforcement for volume access, similar to Velero's spcNoRelabeling option
+				// See: https://velero.io/docs/main/data-movement-backup-pvc-configuration/
+				SELinuxOptions: &corev1.SELinuxOptions{
+					Type: "spc_t",
+				},
+			},
 		},
 	}
 
-	// Add owner reference if VMFR UID is provided
-	if config.VMFRUID != "" {
-		pod.OwnerReferences = []metav1.OwnerReference{
-			{
-				APIVersion:         "oadp.openshift.io/v1alpha1",
-				Kind:               "VirtualMachineFileRestore",
-				Name:               config.VMFRName,
-				UID:                types.UID(config.VMFRUID),
-				Controller:         ptr.To(true),
-				BlockOwnerDeletion: ptr.To(true),
-			},
-		}
-	}
+	// NOTE: No owner references added to the Pod
+	// Kubernetes does not allow cross-namespace owner references (VMFR is in OADP namespace,
+	// Pod is in temp restore namespace). Instead, cleanup is handled by:
+	// 1. Temp namespace has owner reference to VMFR
+	// 2. When VMFR is deleted, namespace is deleted
+	// 3. Namespace deletion cascades to all resources including this Pod
+	// Labels (VMFROriginUUIDLabel) are used for tracking ownership instead
 
 	return pod, nil
 }
@@ -530,14 +591,40 @@ func buildDefaultMainContainer(pvcVolumeMounts []corev1.VolumeMount, enableDualP
 
 // buildVMFileServerMainContainer creates a VM file server container for mounting VM disk images
 // This container uses libguestfs/QEMU to mount VM disks and provide file-level access
+// Based on CONTROLLER_INTEGRATION.md from Issue #6/#7
 func buildVMFileServerMainContainer() corev1.Container {
 	return corev1.Container{
 		Name:  "vm-file-server",
 		Image: constant.VMFileServerImage,
-		Command: []string{
-			"/bin/sh",
-			"-c",
-			"echo 'VM file server starting...'; sleep infinity",
+		// Run detect-and-mount.sh to automatically mount all disk images
+		Command: []string{"/usr/local/bin/detect-and-mount.sh"},
+
+		// Environment variables
+		Env: []corev1.EnvVar{
+			{
+				Name:  "HOME",
+				Value: "/tmp", // Required for libguestfs cache
+			},
+		},
+
+		// Container-level security context
+		// CRITICAL: Privileged mode required for /dev/kvm access with SELinux
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: ptr.To(true), // Required for /dev/kvm and /dev/fuse access
+			RunAsUser:  ptr.To(int64(107)), // qemu user
+			RunAsGroup: ptr.To(int64(107)), // qemu group
+		},
+
+		// Resource limits
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceCPU:    resource.MustParse("250m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("2Gi"),  // libguestfs can use significant memory
+				corev1.ResourceCPU:    resource.MustParse("1000m"), // KVM uses CPU during mount
+			},
 		},
 	}
 }
@@ -619,7 +706,7 @@ func buildInitContainerForDualPathSymlinks(pvcMounts []PVCMountInfo) corev1.Cont
 
 	return corev1.Container{
 		Name:  "setup-dual-path-symlinks",
-		Image: "busybox:latest",
+		Image: "quay.io/quay/busybox:latest",
 		Command: []string{
 			"/bin/sh",
 			"-c",
@@ -727,8 +814,8 @@ func extractPVCMountsFromVMFR(vmfr *oadpv1alpha1.VirtualMachineFileRestore) []PV
 		// Find the most recent successfully completed restore for this PVC
 		// Restores are already sorted by timestamp (newest first) in processDiscoveryResults
 		for _, restoreInfo := range pvcRestore.Restores {
-			// Only include completed restores
-			if restoreInfo.Phase == "Completed" && restoreInfo.State == string(oadptypes.BackupDiscoveryStateAvailable) {
+			// Include both Completed and Finalizing phases (PVCs are ready in both cases)
+			if (restoreInfo.Phase == "Completed" || restoreInfo.Phase == "Finalizing") && restoreInfo.State == string(oadptypes.BackupDiscoveryStateAvailable) {
 				pvcMounts = append(pvcMounts, PVCMountInfo{
 					PVCName:           pvcRestore.PVCName,
 					PVCNamespace:      pvcRestore.PVCNamespace,
@@ -943,15 +1030,15 @@ echo "Configuring public key authentication..."
 cp /credentials/publicKey /config/ssh_keys/authorized_keys
 chmod 600 /config/ssh_keys/authorized_keys
 
-# Set proper ownership (SSH server runs as PUID/PGID 1000)
-chown -R 1000:1000 /config
+# Note: No chown needed - OpenShift's restricted-v2 SCC doesn't allow it,
+# and EmptyDir volumes are created with pod's fsGroup ownership automatically
 
 echo "SSH configuration completed successfully (public key auth only)"
 `
 
 	return corev1.Container{
 		Name:  "setup-ssh-credentials",
-		Image: "busybox:latest",
+		Image: "quay.io/quay/busybox:latest",
 		Command: []string{
 			"/bin/sh",
 			"-c",
@@ -966,6 +1053,48 @@ echo "SSH configuration completed successfully (public key auth only)"
 				Name:      "ssh-credentials",
 				MountPath: "/credentials",
 				ReadOnly:  true,
+			},
+		},
+	}
+}
+
+// buildSSHInitContainerInline creates an init container that configures SSH from inline publicKey.
+func buildSSHInitContainerInline(publicKey string) corev1.Container {
+	// Shell script to configure SSH user from inline publicKey
+	// The publicKey is embedded directly in the script
+	setupScript := fmt.Sprintf(`#!/bin/sh
+set -e
+
+echo "Setting up SSH configuration from inline publicKey..."
+
+# Create SSH keys directory
+mkdir -p /config/ssh_keys
+
+# Write the public key to authorized_keys
+cat > /config/ssh_keys/authorized_keys <<'EOF'
+%s
+EOF
+
+chmod 600 /config/ssh_keys/authorized_keys
+
+# Note: No chown needed - OpenShift's restricted-v2 SCC doesn't allow it,
+# and EmptyDir volumes are created with pod's fsGroup ownership automatically
+
+echo "SSH configuration completed successfully"
+`, publicKey)
+
+	return corev1.Container{
+		Name:  "setup-ssh-credentials",
+		Image: "quay.io/quay/busybox:latest",
+		Command: []string{
+			"/bin/sh",
+			"-c",
+			setupScript,
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "ssh-config",
+				MountPath: "/config",
 			},
 		},
 	}

--- a/internal/controller/fileserver_helpers.go
+++ b/internal/controller/fileserver_helpers.go
@@ -18,6 +18,7 @@ limitations under the License.
 package controller
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -250,15 +251,8 @@ func buildFileServerPodSpec(config FileServerPodConfig) (*corev1.Pod, error) {
 		})
 	}
 
-	// Add EmptyDir for dual-path symlinks if enabled
-	if config.EnableDualPathAccess {
-		allVolumes = append(allVolumes, corev1.Volume{
-			Name: "restores-by-date",
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		})
-	}
+	// Note: /restores_by_name and /restores_by_date are created by the script at runtime
+	// No need to create EmptyDir volumes - script creates these as regular directories
 
 	// Add /dev/fuse hostPath volume (required for guestmount FUSE filesystem)
 	allVolumes = append(allVolumes, corev1.Volume{
@@ -324,14 +318,8 @@ func buildFileServerPodSpec(config FileServerPodConfig) (*corev1.Pod, error) {
 		allInitContainers = append(allInitContainers, fileBrowserInitContainers...)
 	}
 
-	// Add dual-path symlink init container if enabled
-	if config.EnableDualPathAccess {
-		symlinkInit := buildInitContainerForDualPathSymlinks(config.PVCMounts)
-		// Add PVC volume mounts to symlink init container
-		symlinkInit.VolumeMounts = append(symlinkInit.VolumeMounts, pvcVolumeMounts...)
-		// Prepend so it runs before sidecar init containers
-		allInitContainers = append([]corev1.Container{symlinkInit}, allInitContainers...)
-	}
+	// Dual-path symlink structure is now created by the file server detect-and-mount.sh script
+	// after mounting filesystems, eliminating the init container dependency issue
 
 	// Build or use default main container
 	var mainContainer corev1.Container
@@ -371,15 +359,6 @@ func buildFileServerPodSpec(config FileServerPodConfig) (*corev1.Pod, error) {
 		// Inject PVC volume mounts (Filesystem mode) and volume devices (Block mode) into the main container
 		mainContainer.VolumeMounts = append(mainContainer.VolumeMounts, pvcVolumeMounts...)
 		mainContainer.VolumeDevices = append(mainContainer.VolumeDevices, pvcVolumeDevices...)
-
-		// If dual-path is enabled, also mount the symlink directory
-		if config.EnableDualPathAccess {
-			mainContainer.VolumeMounts = append(mainContainer.VolumeMounts, corev1.VolumeMount{
-				Name:      "restores-by-date",
-				MountPath: "/restores_by_date",
-				ReadOnly:  true,
-			})
-		}
 
 		// Add /dev/fuse device mount (required for guestmount)
 		mainContainer.VolumeMounts = append(mainContainer.VolumeMounts, corev1.VolumeMount{
@@ -587,15 +566,6 @@ func buildDefaultMainContainer(pvcVolumeMounts []corev1.VolumeMount, enableDualP
 	volumeMounts := make([]corev1.VolumeMount, len(pvcVolumeMounts))
 	copy(volumeMounts, pvcVolumeMounts)
 
-	// Add dual-path mount if enabled
-	if enableDualPath {
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "restores-by-date",
-			MountPath: "/restores_by_date",
-			ReadOnly:  true,
-		})
-	}
-
 	return corev1.Container{
 		Name:  "file-server",
 		Image: "busybox:latest",
@@ -619,7 +589,10 @@ func buildDefaultMainContainer(pvcVolumeMounts []corev1.VolumeMount, enableDualP
 // buildVMFileServerMainContainer creates a VM file server container for mounting VM disk images
 // This container uses libguestfs/QEMU to mount VM disks and provide file-level access
 // Based on CONTROLLER_INTEGRATION.md from Issue #6/#7
-func buildVMFileServerMainContainer() corev1.Container {
+func buildVMFileServerMainContainer(pvcMounts []PVCMountInfo) corev1.Container {
+	// Build BACKUP_PVC_MAP JSON for the file server script
+	backupPVCMap := buildBackupPVCMapJSON(pvcMounts)
+
 	return corev1.Container{
 		Name:  "vm-file-server",
 		Image: constant.VMFileServerImage,
@@ -631,6 +604,10 @@ func buildVMFileServerMainContainer() corev1.Container {
 			{
 				Name:  "HOME",
 				Value: "/tmp", // Required for libguestfs cache
+			},
+			{
+				Name:  "BACKUP_PVC_MAP",
+				Value: backupPVCMap, // JSON mapping of backups to PVCs for dual-path structure
 			},
 		},
 
@@ -654,6 +631,56 @@ func buildVMFileServerMainContainer() corev1.Container {
 			},
 		},
 	}
+}
+
+// buildBackupPVCMapJSON builds a JSON string mapping backup names to PVC information
+// This is used by the file server script to create the dual-path directory structure
+//
+// Format: {"backup-name": [{"name": "pvc-name", "path": "/dev/pvc-{uid}", "timestamp": "2025-10-23T18:40:00Z"}]}
+//
+// Example output:
+//
+//	{
+//	  "test-vm-backup-20250115": [
+//	    {"name": "test-vm-disk-1", "path": "/dev/pvc-5685cd9a-56b4-4482-9236-17b7cc4b0dff", "timestamp": "2025-10-23T18:40:00Z"}
+//	  ]
+//	}
+func buildBackupPVCMapJSON(pvcMounts []PVCMountInfo) string {
+	// Group PVCs by backup name
+	backupMap := make(map[string][]map[string]string)
+
+	for _, pvcMount := range pvcMounts {
+		backupName := pvcMount.BackupName
+
+		// Build device path based on volumeMode
+		// Block mode: /dev/pvc-{uid}
+		// Filesystem mode: /restores_by_name/{backup}/{uid} (but we use the UID-based path for consistency)
+		devicePath := fmt.Sprintf("/dev/pvc-%s", pvcMount.PVCUID)
+
+		// Format timestamp as ISO8601
+		timestamp := ""
+		if pvcMount.BackupTimestamp != nil {
+			timestamp = pvcMount.BackupTimestamp.Format("2006-01-02T15:04:05Z")
+		}
+
+		// Create PVC entry
+		pvcEntry := map[string]string{
+			"name":      pvcMount.PVCName,
+			"path":      devicePath,
+			"timestamp": timestamp,
+		}
+
+		backupMap[backupName] = append(backupMap[backupName], pvcEntry)
+	}
+
+	// Marshal to JSON
+	jsonBytes, err := json.Marshal(backupMap)
+	if err != nil {
+		// If marshaling fails, return empty JSON object (script will skip dual-path creation)
+		return "{}"
+	}
+
+	return string(jsonBytes)
 }
 
 // buildPodLabels creates labels for the pod
@@ -698,54 +725,6 @@ func buildPodAnnotations(config FileServerPodConfig) map[string]string {
 	}
 
 	return annotations
-}
-
-// buildInitContainerForDualPathSymlinks creates an init container that sets up symlinks
-// to provide dual-path access to the same PVCs:
-// - /restores_by_name/<backup-name>/<pvc-uid> (actual mount point)
-// - /restores_by_date/<date>/<pvc-name> (symlink to above)
-func buildInitContainerForDualPathSymlinks(pvcMounts []PVCMountInfo) corev1.Container {
-	// Build shell commands to create symlink structure
-	commands := []string{"set -e"} // Exit on error
-
-	// Create base directory
-	commands = append(commands, "mkdir -p /restores_by_date")
-
-	for _, pvcMount := range pvcMounts {
-		// Format date as YYYY-MM-DD
-		backupDate := formatBackupDate(pvcMount.BackupTimestamp)
-
-		// Source: /restores_by_name/<backup-name>/<pvc-uid>
-		sourcePath := fmt.Sprintf("/restores_by_name/%s/%s", pvcMount.BackupName, pvcMount.PVCUID)
-
-		// Target: /restores_by_date/<date>/<pvc-name>
-		targetDir := fmt.Sprintf("/restores_by_date/%s", backupDate)
-		targetPath := fmt.Sprintf("%s/%s", targetDir, pvcMount.PVCName)
-
-		// Create date directory and symlink
-		commands = append(commands,
-			fmt.Sprintf("mkdir -p %s", targetDir),
-			fmt.Sprintf("ln -sf %s %s", sourcePath, targetPath),
-		)
-	}
-
-	commands = append(commands, "echo 'Dual-path symlinks created successfully'")
-
-	return corev1.Container{
-		Name:  "setup-dual-path-symlinks",
-		Image: "quay.io/quay/busybox:latest",
-		Command: []string{
-			"/bin/sh",
-			"-c",
-			strings.Join(commands, "\n"),
-		},
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "restores-by-date",
-				MountPath: "/restores_by_date",
-			},
-		},
-	}
 }
 
 // buildFileServerService builds a Service spec for exposing file server pod ports
@@ -1003,13 +982,6 @@ func buildSSHSidecar(
 	} else {
 		// Kubernetes-managed mode: mount PVCs directly
 		container.VolumeMounts = append(container.VolumeMounts, pvcVolumeMounts...)
-		if enableDualPath {
-			container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-				Name:      "restores-by-date",
-				MountPath: "/restores_by_date",
-				ReadOnly:  true,
-			})
-		}
 	}
 
 	// Add Secret volume and init container for SSH configuration
@@ -1216,13 +1188,6 @@ func buildFileBrowserSidecar(
 	} else {
 		// Kubernetes-managed mode: mount PVCs directly
 		container.VolumeMounts = append(container.VolumeMounts, pvcVolumeMounts...)
-		if enableDualPath {
-			container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-				Name:      "restores-by-date",
-				MountPath: "/restores_by_date",
-				ReadOnly:  true,
-			})
-		}
 	}
 
 	// Init container to configure FileBrowser database and create user

--- a/internal/controller/virtualmachinefilerestore_controller.go
+++ b/internal/controller/virtualmachinefilerestore_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/go-logr/logr"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -86,11 +87,15 @@ func (e ErrUnsupportedBackup) Error() string {
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=velero.io,resources=restores,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=velero.io,resources=backups,verbs=get;list;watch
+// +kubebuilder:rbac:groups=velero.io,resources=downloadrequests,verbs=get;list;watch;create;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -1843,6 +1848,66 @@ func (r *VirtualMachineFileRestoreReconciler) ensureRestoreNamespace(
 		logger.V(0).Info("Created temporary restore namespace", "namespace", namespaceName)
 	}
 
+	// Create ServiceAccount for file server pods with privileged SCC access
+	serviceAccountName := "vmfr-file-server"
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceAccountName,
+			Namespace: namespaceName,
+			Labels: map[string]string{
+				constant.VMFROriginUUIDLabel: string(vmfr.UID),
+				constant.ManagedByLabel:      constant.ManagedByLabelValue,
+			},
+		},
+	}
+
+	err = r.Create(ctx, serviceAccount)
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			logger.V(1).Info("ServiceAccount already exists", "serviceAccount", serviceAccountName, "namespace", namespaceName)
+		} else {
+			return "", fmt.Errorf("failed to create ServiceAccount '%s' in namespace '%s': %w", serviceAccountName, namespaceName, err)
+		}
+	} else {
+		logger.V(0).Info("Created ServiceAccount for file server", "serviceAccount", serviceAccountName, "namespace", namespaceName)
+	}
+
+	// Bind ServiceAccount to privileged SCC via RoleBinding
+	// This grants the file server pod permission to use privileged mode, hostPath volumes, and spc_t SELinux type
+	sccRoleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vmfr-file-server-privileged",
+			Namespace: namespaceName,
+			Labels: map[string]string{
+				constant.VMFROriginUUIDLabel: string(vmfr.UID),
+				constant.ManagedByLabel:      constant.ManagedByLabelValue,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "system:openshift:scc:privileged",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccountName,
+				Namespace: namespaceName,
+			},
+		},
+	}
+
+	err = r.Create(ctx, sccRoleBinding)
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			logger.V(1).Info("SCC RoleBinding already exists", "roleBinding", "vmfr-file-server-privileged", "namespace", namespaceName)
+		} else {
+			return "", fmt.Errorf("failed to create SCC RoleBinding in namespace '%s': %w", namespaceName, err)
+		}
+	} else {
+		logger.V(0).Info("Bound ServiceAccount to privileged SCC", "roleBinding", "vmfr-file-server-privileged", "namespace", namespaceName)
+	}
+
 	// Update VMFR status with the created namespace
 	patch := client.MergeFrom(vmfr.DeepCopy())
 	vmfr.Status.CreatedNamespace = namespaceName
@@ -2158,9 +2223,11 @@ func (r *VirtualMachineFileRestoreReconciler) monitorVeleroRestores(
 
 		// Categorize by phase
 		switch restorePhase {
-		case veleroapi.RestorePhaseCompleted:
+		case veleroapi.RestorePhaseCompleted, veleroapi.RestorePhaseFinalizing:
+			// Treat Finalizing as completed since PVCs are already restored and available for mounting
 			completed++
-		case veleroapi.RestorePhaseFailed, veleroapi.RestorePhasePartiallyFailed, veleroapi.RestorePhaseFailedValidation:
+		case veleroapi.RestorePhaseFailed, veleroapi.RestorePhasePartiallyFailed, veleroapi.RestorePhaseFailedValidation,
+			"FinalizingPartiallyFailed": // Velero is finalizing a partially failed restore
 			failed++
 		case veleroapi.RestorePhaseNew, veleroapi.RestorePhaseInProgress, veleroapi.RestorePhaseFinalizing, veleroapi.RestorePhaseFinalizingPartiallyFailed, "":
 			// Finalizing* phases are transitional states - wait for terminal state
@@ -2410,6 +2477,9 @@ func (r *VirtualMachineFileRestoreReconciler) createFileServerResources(
 	var sshConfig *SSHAccessConfig
 	var fileBrowserConfig *FileBrowserAccessConfig
 
+	// TODO: Re-enable SSH/FileBrowser sidecars after Increment 1 is complete
+	// For now, commenting out to focus on core file server functionality
+	/*
 	// Configure SSH access if enabled
 	if vmfr.Spec.FileAccess != nil && vmfr.Spec.FileAccess.SSH != nil {
 		sshSpec := vmfr.Spec.FileAccess.SSH
@@ -2538,6 +2608,7 @@ func (r *VirtualMachineFileRestoreReconciler) createFileServerResources(
 			}
 		}
 	}
+	*/
 
 	// Build pod configuration with parsed access methods
 	podConfig := FileServerPodConfig{
@@ -2558,22 +2629,26 @@ func (r *VirtualMachineFileRestoreReconciler) createFileServerResources(
 		"sshEnabled", sshConfig != nil,
 		"fileBrowserEnabled", fileBrowserConfig != nil)
 
-	// Build deployment spec (uses VM file server container)
-	deployment, err := buildFileServerDeployment(podConfig)
+	// Build pod spec (uses VM file server container)
+	// Note: Using Pod instead of Deployment because:
+	// 1. ReadWriteOnce PVCs can only be mounted by one pod
+	// 2. No cross-namespace owner references allowed (VMFR in OADP ns, Pod in temp ns)
+	// 3. Cleanup handled by namespace deletion (namespace has owner ref to VMFR)
+	pod, err := buildFileServerPodSpec(podConfig)
 	if err != nil {
-		return fmt.Errorf("failed to build deployment spec: %w", err)
+		return fmt.Errorf("failed to build pod spec: %w", err)
 	}
 
-	// Create the deployment
-	err = r.Create(ctx, deployment)
+	// Create the pod
+	err = r.Create(ctx, pod)
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			logger.V(1).Info("File server deployment already exists", "deploymentName", deployment.Name)
+			logger.V(1).Info("File server pod already exists", "podName", pod.Name)
 		} else {
-			return fmt.Errorf("failed to create file server deployment: %w", err)
+			return fmt.Errorf("failed to create file server pod: %w", err)
 		}
 	} else {
-		logger.V(0).Info("Created file server deployment", "deploymentName", deployment.Name, "namespace", deployment.Namespace)
+		logger.V(0).Info("Created file server pod", "podName", pod.Name, "namespace", pod.Namespace)
 	}
 
 	// Build service configuration
@@ -2612,7 +2687,7 @@ func (r *VirtualMachineFileRestoreReconciler) createFileServerResources(
 	}
 
 	logger.V(0).Info("File server resources created successfully",
-		"deploymentName", deployment.Name,
+		"podName", pod.Name,
 		"serviceName", service.Name,
 		"namespace", restoreNamespace)
 

--- a/internal/controller/virtualmachinefilerestore_controller.go
+++ b/internal/controller/virtualmachinefilerestore_controller.go
@@ -118,8 +118,8 @@ func (r *VirtualMachineFileRestoreReconciler) Reconcile(ctx context.Context, req
 		// Deletion path - handle finalizer-based cleanup
 		logger.V(0).Info("Executing deletion path")
 		reconcileSteps = []virtualmachinefilerestoreReconcileStepFunction{
-			// r.handleResourceDeletion,
-			// TBD handle resource deletion
+			r.handleVeleroRestoreCleanup,
+			r.handleResourceCleanup,
 		}
 
 	case vmfr.Status.Phase == "":
@@ -3040,5 +3040,284 @@ func (r *VirtualMachineFileRestoreReconciler) ensureCredentials(
 	}
 
 	logger.V(0).Info("All credentials ready for file server creation")
+	return nil
+}
+
+// handleVeleroRestoreCleanup deletes Velero Restore objects created by this VMFR.
+// This finalizer runs first to ensure Velero Restores are cleaned up before
+// other resources that they may reference.
+func (r *VirtualMachineFileRestoreReconciler) handleVeleroRestoreCleanup(
+	ctx context.Context,
+	logger logr.Logger,
+	vmfr *oadpv1alpha1.VirtualMachineFileRestore,
+) (bool, error) {
+	if !controllerutil.ContainsFinalizer(vmfr, constant.VeleroRestoreCleanupFinalizer) {
+		logger.V(1).Info("VeleroRestoreCleanupFinalizer already removed, skipping")
+		return false, nil
+	}
+
+	logger.V(0).Info("Cleaning up Velero Restore objects")
+
+	// Find all Velero Restore objects created by this VMFR using label selector
+	restoreList := &veleroapi.RestoreList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(r.OADPNamespace),
+		client.MatchingLabels{
+			constant.VMFROriginUUIDLabel: string(vmfr.UID),
+		},
+	}
+
+	if err := r.List(ctx, restoreList, listOpts...); err != nil {
+		logger.Error(err, "Failed to list Velero Restore objects for cleanup")
+		return false, fmt.Errorf("failed to list Velero Restore objects: %w", err)
+	}
+
+	logger.V(0).Info("Found Velero Restore objects to delete", "count", len(restoreList.Items))
+
+	deletedCount := 0
+	for i := range restoreList.Items {
+		restore := &restoreList.Items[i]
+		logger.V(1).Info("Deleting Velero Restore", "name", restore.Name, "namespace", restore.Namespace)
+
+		if err := r.Delete(ctx, restore); err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.V(1).Info("Velero Restore already deleted", "name", restore.Name)
+				continue
+			}
+			logger.Error(err, "Failed to delete Velero Restore", "name", restore.Name)
+			return false, fmt.Errorf("failed to delete Velero Restore %s: %w", restore.Name, err)
+		}
+		deletedCount++
+	}
+
+	logger.V(0).Info("Deleted Velero Restore objects", "count", deletedCount)
+
+	// Remove this finalizer to proceed to next cleanup step
+	patch := client.MergeFrom(vmfr.DeepCopy())
+	controllerutil.RemoveFinalizer(vmfr, constant.VeleroRestoreCleanupFinalizer)
+	if err := r.Patch(ctx, vmfr, patch); err != nil {
+		logger.Error(err, "Failed to remove VeleroRestoreCleanupFinalizer")
+		return false, fmt.Errorf("failed to remove VeleroRestoreCleanupFinalizer: %w", err)
+	}
+
+	logger.V(0).Info("Removed VeleroRestoreCleanupFinalizer")
+	return true, nil
+}
+
+// handleResourceCleanup cleans up namespace, PVCs, and secrets based on namespace ownership.
+// For temporary namespaces created by the controller, the entire namespace is deleted
+// (which cascades to all contained resources). For user-provided namespaces, only
+// resources created by this controller are individually deleted.
+func (r *VirtualMachineFileRestoreReconciler) handleResourceCleanup(
+	ctx context.Context,
+	logger logr.Logger,
+	vmfr *oadpv1alpha1.VirtualMachineFileRestore,
+) (bool, error) {
+	if !controllerutil.ContainsFinalizer(vmfr, constant.VMFileRestoreFinalizer) {
+		logger.V(1).Info("VMFileRestoreFinalizer already removed, skipping")
+		return false, nil
+	}
+
+	logger.V(0).Info("Cleaning up VMFR resources")
+
+	restoreNamespace := vmfr.Status.CreatedNamespace
+	if restoreNamespace == "" {
+		logger.V(0).Info("No restore namespace found in status, skipping resource cleanup")
+		patch := client.MergeFrom(vmfr.DeepCopy())
+		controllerutil.RemoveFinalizer(vmfr, constant.VMFileRestoreFinalizer)
+		if err := r.Patch(ctx, vmfr, patch); err != nil {
+			logger.Error(err, "Failed to remove VMFileRestoreFinalizer")
+			return false, fmt.Errorf("failed to remove VMFileRestoreFinalizer: %w", err)
+		}
+		logger.V(0).Info("Removed VMFileRestoreFinalizer (no namespace to clean)")
+		return false, nil
+	}
+
+	// Check if namespace exists and determine if it's controller-managed
+	namespace := &corev1.Namespace{}
+	err := r.Get(ctx, types.NamespacedName{Name: restoreNamespace}, namespace)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(0).Info("Restore namespace already deleted", "namespace", restoreNamespace)
+			patch := client.MergeFrom(vmfr.DeepCopy())
+			controllerutil.RemoveFinalizer(vmfr, constant.VMFileRestoreFinalizer)
+			if err := r.Patch(ctx, vmfr, patch); err != nil {
+				logger.Error(err, "Failed to remove VMFileRestoreFinalizer")
+				return false, fmt.Errorf("failed to remove VMFileRestoreFinalizer: %w", err)
+			}
+			logger.V(0).Info("Removed VMFileRestoreFinalizer (namespace already deleted)")
+			return false, nil
+		}
+		logger.Error(err, "Failed to get restore namespace", "namespace", restoreNamespace)
+		return false, fmt.Errorf("failed to get restore namespace: %w", err)
+	}
+
+	// Determine cleanup strategy based on namespace ownership
+	isTempNamespace := namespace.Labels != nil &&
+		namespace.Labels[constant.VMFRTempNamespaceLabel] == constant.TrueString
+
+	if isTempNamespace {
+		// Delete the entire temporary namespace - Kubernetes will cascade to all resources
+		logger.V(0).Info("Deleting temporary namespace created by controller",
+			"namespace", restoreNamespace)
+
+		if err := r.Delete(ctx, namespace); err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.V(1).Info("Temporary namespace already deleted", "namespace", restoreNamespace)
+			} else {
+				logger.Error(err, "Failed to delete temporary namespace", "namespace", restoreNamespace)
+				return false, fmt.Errorf("failed to delete temporary namespace: %w", err)
+			}
+		} else {
+			logger.V(0).Info("Temporary namespace deletion initiated", "namespace", restoreNamespace)
+		}
+	} else {
+		// User-provided namespace - selectively delete only controller-created resources
+		logger.V(0).Info("Cleaning up controller resources in user-provided namespace",
+			"namespace", restoreNamespace)
+
+		// Delete PVCs restored by this VMFR's Velero Restore objects
+		if err := r.deleteRestoredPVCs(ctx, logger, vmfr, restoreNamespace); err != nil {
+			return false, err
+		}
+
+		// Delete secrets created or copied by this controller
+		if err := r.deleteControllerSecrets(ctx, logger, vmfr, restoreNamespace); err != nil {
+			return false, err
+		}
+
+		logger.V(0).Info("Completed cleanup of controller resources",
+			"namespace", restoreNamespace)
+	}
+
+	// Remove the main finalizer - VMFR can now be deleted
+	patch := client.MergeFrom(vmfr.DeepCopy())
+	controllerutil.RemoveFinalizer(vmfr, constant.VMFileRestoreFinalizer)
+	if err := r.Patch(ctx, vmfr, patch); err != nil {
+		logger.Error(err, "Failed to remove VMFileRestoreFinalizer")
+		return false, fmt.Errorf("failed to remove VMFileRestoreFinalizer: %w", err)
+	}
+
+	logger.V(0).Info("Removed VMFileRestoreFinalizer, VMFR cleanup complete")
+	return false, nil
+}
+
+// deleteRestoredPVCs removes PVCs that were created by this VMFR's Velero Restore operations.
+// PVCs are identified by the Velero restore label that matches restore names from VMFR status.
+func (r *VirtualMachineFileRestoreReconciler) deleteRestoredPVCs(
+	ctx context.Context,
+	logger logr.Logger,
+	vmfr *oadpv1alpha1.VirtualMachineFileRestore,
+	namespace string,
+) error {
+	logger.V(0).Info("Deleting restored PVCs", "namespace", namespace)
+
+	// Extract unique Velero Restore names from VMFR status
+	restoreNames := make(map[string]bool)
+	for _, pvcRestore := range vmfr.Status.PVCRestores {
+		for _, restoreInfo := range pvcRestore.Restores {
+			if restoreInfo.VeleroRestoreName != "" {
+				restoreNames[restoreInfo.VeleroRestoreName] = true
+			}
+		}
+	}
+
+	if len(restoreNames) == 0 {
+		logger.V(1).Info("No Velero Restore names found in status, skipping PVC deletion")
+		return nil
+	}
+
+	logger.V(1).Info("Found Velero Restore names from status", "count", len(restoreNames))
+
+	// Delete PVCs for each Velero Restore using the restore label
+	deletedCount := 0
+	for restoreName := range restoreNames {
+		pvcList := &corev1.PersistentVolumeClaimList{}
+		listOpts := []client.ListOption{
+			client.InNamespace(namespace),
+			client.MatchingLabels{
+				"velero.io/restore-name": restoreName,
+			},
+		}
+
+		if err := r.List(ctx, pvcList, listOpts...); err != nil {
+			logger.Error(err, "Failed to list PVCs for Velero Restore", "restoreName", restoreName)
+			return fmt.Errorf("failed to list PVCs for restore %s: %w", restoreName, err)
+		}
+
+		logger.V(1).Info("Found PVCs for Velero Restore",
+			"restoreName", restoreName,
+			"pvcCount", len(pvcList.Items))
+
+		for i := range pvcList.Items {
+			pvc := &pvcList.Items[i]
+			logger.V(1).Info("Deleting PVC",
+				"pvcName", pvc.Name,
+				"namespace", pvc.Namespace,
+				"restoreName", restoreName)
+
+			if err := r.Delete(ctx, pvc); err != nil {
+				if apierrors.IsNotFound(err) {
+					logger.V(1).Info("PVC already deleted", "pvcName", pvc.Name)
+					continue
+				}
+				logger.Error(err, "Failed to delete PVC", "pvcName", pvc.Name)
+				return fmt.Errorf("failed to delete PVC %s: %w", pvc.Name, err)
+			}
+			deletedCount++
+		}
+	}
+
+	logger.V(0).Info("Deleted restored PVCs", "count", deletedCount, "namespace", namespace)
+	return nil
+}
+
+// deleteControllerSecrets removes secrets created or copied by this controller.
+// Secrets are identified by the VMFROriginUUIDLabel matching this VMFR's UID.
+// This includes both copied secrets (from other namespaces) and generated credentials.
+func (r *VirtualMachineFileRestoreReconciler) deleteControllerSecrets(
+	ctx context.Context,
+	logger logr.Logger,
+	vmfr *oadpv1alpha1.VirtualMachineFileRestore,
+	namespace string,
+) error {
+	logger.V(0).Info("Deleting controller-created secrets", "namespace", namespace)
+
+	secretList := &corev1.SecretList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			constant.VMFROriginUUIDLabel: string(vmfr.UID),
+		},
+	}
+
+	if err := r.List(ctx, secretList, listOpts...); err != nil {
+		logger.Error(err, "Failed to list controller secrets")
+		return fmt.Errorf("failed to list controller secrets: %w", err)
+	}
+
+	logger.V(0).Info("Found controller-created secrets to delete", "count", len(secretList.Items))
+
+	deletedCount := 0
+	for i := range secretList.Items {
+		secret := &secretList.Items[i]
+		logger.V(1).Info("Deleting controller secret",
+			"secretName", secret.Name,
+			"namespace", secret.Namespace,
+			"isCopy", secret.Labels[constant.VMFRManagedCopyLabel] == constant.TrueString,
+			"credentialType", secret.Labels[constant.CredentialTypeLabel])
+
+		if err := r.Delete(ctx, secret); err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.V(1).Info("Secret already deleted", "secretName", secret.Name)
+				continue
+			}
+			logger.Error(err, "Failed to delete secret", "secretName", secret.Name)
+			return fmt.Errorf("failed to delete secret %s: %w", secret.Name, err)
+		}
+		deletedCount++
+	}
+
+	logger.V(0).Info("Deleted controller-created secrets", "count", deletedCount, "namespace", namespace)
 	return nil
 }

--- a/internal/controller/virtualmachinefilerestore_controller.go
+++ b/internal/controller/virtualmachinefilerestore_controller.go
@@ -2269,11 +2269,10 @@ func (r *VirtualMachineFileRestoreReconciler) monitorVeleroRestores(
 		case veleroapi.RestorePhaseCompleted, veleroapi.RestorePhaseFinalizing:
 			// Treat Finalizing as completed since PVCs are already restored and available for mounting
 			completed++
-		case veleroapi.RestorePhaseFailed, veleroapi.RestorePhasePartiallyFailed, veleroapi.RestorePhaseFailedValidation,
-			"FinalizingPartiallyFailed": // Velero is finalizing a partially failed restore
+		case veleroapi.RestorePhaseFailed, veleroapi.RestorePhasePartiallyFailed, veleroapi.RestorePhaseFailedValidation:
 			failed++
-		case veleroapi.RestorePhaseNew, veleroapi.RestorePhaseInProgress, veleroapi.RestorePhaseFinalizing, veleroapi.RestorePhaseFinalizingPartiallyFailed, "":
-			// Finalizing* phases are transitional states - wait for terminal state
+		case veleroapi.RestorePhaseNew, veleroapi.RestorePhaseInProgress, "":
+			// Still in progress
 			inProgress++
 		default:
 			logger.V(1).Info("Unknown Velero Restore phase, treating as in-progress",
@@ -2782,7 +2781,6 @@ func (r *VirtualMachineFileRestoreReconciler) createFileServerResources(
 	return nil
 }
 
-<<<<<<< HEAD
 // ensureSecretInRestoreNamespace ensures a secret is available in the restore namespace.
 // If the secret is already in the restore namespace, it validates and returns the secret name.
 // If the secret is in a different namespace, it validates the source, copies it to the restore
@@ -3205,7 +3203,8 @@ func (r *VirtualMachineFileRestoreReconciler) ensureCredentials(
 
 	logger.V(0).Info("All credentials ready for file server creation")
 	return nil
-=======
+}
+
 // fixDataDownloadPVCNames fixes the DataDownload PVC name mismatch issue caused by kubevirt-velero-plugin.
 // When using Velero Data Mover with kubevirt-velero-plugin, there's a mismatch between the PVC name
 // in the DataDownload spec and the actual restored PVC name:
@@ -3384,7 +3383,6 @@ func (r *VirtualMachineFileRestoreReconciler) fixDataDownloadPVCNames(
 	}
 
 	return fixedCount, nil
->>>>>>> d832fcc (Add Block mode PVC support and DataDownload PVC name auto-fix)
 }
 
 // handleVeleroRestoreCleanup deletes Velero Restore objects created by this VMFR.

--- a/internal/controller/virtualmachinefilerestore_controller.go
+++ b/internal/controller/virtualmachinefilerestore_controller.go
@@ -2329,13 +2329,20 @@ func (r *VirtualMachineFileRestoreReconciler) monitorVeleroRestores(
 					}
 
 					// Always update phase if it changed (even if metadata was already set)
-					if restoreInfo.Phase != restorePhase {
+					// Normalize Finalizing to Completed since from VMFR perspective they're equivalent
+					normalizedPhase := restorePhase
+					if restorePhase == veleroapi.RestorePhaseFinalizing {
+						normalizedPhase = veleroapi.RestorePhaseCompleted
+					}
+
+					if restoreInfo.Phase != normalizedPhase {
 						logger.V(1).Info("Updating RestoreInfo phase",
 							"pvcUID", pvcRestore.PVCUID,
 							"restoreName", restoreName,
 							"oldPhase", restoreInfo.Phase,
-							"newPhase", restorePhase)
-						restoreInfo.Phase = restorePhase
+							"newPhase", normalizedPhase,
+							"veleroPhase", restorePhase)
+						restoreInfo.Phase = normalizedPhase
 						statusUpdated = true
 					}
 				}
@@ -2706,10 +2713,10 @@ func (r *VirtualMachineFileRestoreReconciler) createFileServerResources(
 		VMFRUID:              string(vmfr.UID),
 		PVCMounts:            pvcMounts,
 		MainContainer:        ptr.To(buildVMFileServerMainContainer(pvcMounts)), // Use VM file server for disk mounting
-		SSHAccess:            sshConfig,                                          // Configured SSH access (or nil)
-		FileBrowserAccess:    fileBrowserConfig,                                  // Configured FileBrowser access (or nil)
-		EnableDualPathAccess: true,                                               // Enable dual-path symlinks
-		UseInternalMounts:    false,                                              // Use Kubernetes-managed PVC mounts
+		SSHAccess:            sshConfig,                                         // Configured SSH access (or nil)
+		FileBrowserAccess:    fileBrowserConfig,                                 // Configured FileBrowser access (or nil)
+		EnableDualPathAccess: true,                                              // Enable dual-path symlinks
+		UseInternalMounts:    false,                                             // Use Kubernetes-managed PVC mounts
 	}
 
 	logger.V(0).Info("File server configuration prepared",
@@ -3215,10 +3222,10 @@ func (r *VirtualMachineFileRestoreReconciler) ensureCredentials(
 // This function:
 // 1. Lists DataDownload resources created by our Velero Restores (using VMFR UID label)
 // 2. For each DataDownload with empty/pending status (not started):
-//    - Finds the corresponding Velero Restore from annotations
-//    - Finds the actual restored PVC name by listing PVCs with velero.io/restore-name label
-//    - Matches PVC by original name annotation (constant.VMFROriginalPVCNameAnnotation)
-//    - Patches DataDownload spec.targetVolume.pvc with the actual PVC name
+//   - Finds the corresponding Velero Restore from annotations
+//   - Finds the actual restored PVC name by listing PVCs with velero.io/restore-name label
+//   - Matches PVC by original name annotation (constant.VMFROriginalPVCNameAnnotation)
+//   - Patches DataDownload spec.targetVolume.pvc with the actual PVC name
 //
 // Returns the count of DataDownloads that were patched.
 func (r *VirtualMachineFileRestoreReconciler) fixDataDownloadPVCNames(

--- a/internal/controller/virtualmachinefilerestore_controller.go
+++ b/internal/controller/virtualmachinefilerestore_controller.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/go-logr/logr"
 	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	veleroapiv2alpha1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -96,6 +97,7 @@ func (e ErrUnsupportedBackup) Error() string {
 // +kubebuilder:rbac:groups=velero.io,resources=restores,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=velero.io,resources=backups,verbs=get;list;watch
 // +kubebuilder:rbac:groups=velero.io,resources=downloadrequests,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups=velero.io,resources=datadownloads,verbs=get;list;watch;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -838,6 +840,17 @@ func (r *VirtualMachineFileRestoreReconciler) executeFileRestoreWorkflow(ctx con
 				return false, err
 			}
 			logger.V(1).Info("Successfully updated PVCRestores with Velero Restore phases")
+		}
+
+		// Fix DataDownload PVC name mismatch (if any DataDownloads exist)
+		// This automatically patches DataDownload resources with correct PVC names
+		fixedCount, err := r.fixDataDownloadPVCNames(ctx, logger, vmfr)
+		if err != nil {
+			logger.Error(err, "Failed to fix DataDownload PVC names")
+			// Don't fail the reconciliation - log and continue
+			// The DataDownload will eventually timeout and we can retry
+		} else if fixedCount > 0 {
+			logger.V(0).Info("Fixed DataDownload PVC name mismatches", "count", fixedCount)
 		}
 
 		// If any restores still in progress, requeue periodically to check status
@@ -2058,6 +2071,36 @@ func (r *VirtualMachineFileRestoreReconciler) createVeleroRestores(
 			},
 		}
 
+		// IMPLEMENTED FIX: DataDownload PVC Name Mismatch with kubevirt-velero-plugin
+		// When using Velero Data Mover with kubevirt-velero-plugin, there's a mismatch between
+		// the PVC name in the DataDownload spec and the actual restored PVC name:
+		//
+		// Problem:
+		//   - kubevirt-velero-plugin modifies PVC names during restore (adds backup name prefix + suffix)
+		//   - Example: "test-vm-rootdisk" becomes "vm-backup-test-vm-rootdisk-abc123"
+		//   - But DataDownload is created with original PVC name in spec.targetVolume.pvc
+		//   - DataDownload controller can't find the PVC and gets stuck (no progress)
+		//
+		// Automatic Fix (implemented in fixDataDownloadPVCNames function):
+		//   - Called in the WaitingForRestores phase during monitorVeleroRestores (see line 843)
+		//   - Lists DataDownload objects created by our Velero Restores (using VMFR UID label)
+		//   - For each DataDownload with empty/New status (not started):
+		//     - Finds the corresponding Velero Restore from owner references
+		//     - Finds the actual restored PVC name by listing PVCs with velero.io/restore-name label
+		//     - Matches PVC by original name annotation (constant.VMFROriginalPVCNameAnnotation)
+		//     - Patches DataDownload spec.targetVolume.pvc with the actual PVC name
+		//   - Returns count of DataDownloads that were patched
+		//   - Errors are logged but don't fail reconciliation (will retry on next reconcile)
+		//
+		// Implementation Details:
+		//   - See fixDataDownloadPVCNames function (line 2715)
+		//   - Uses JSON patch to update spec.targetVolume.pvc field
+		//   - Handles cases where PVC hasn't been created yet (will retry)
+		//   - Skips DataDownloads that are already in progress
+		//
+		// Impact: Critical for Block mode PVCs with Data Mover (VM disk restores)
+		// This fix enables automatic Data Mover restores without manual intervention
+
 		// Create Velero Restore object with generateName
 		restore := &veleroapi.Restore{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2455,16 +2498,39 @@ func (r *VirtualMachineFileRestoreReconciler) createFileServerResources(
 		return fmt.Errorf("no PVC mounts found in status")
 	}
 
-	// Populate the actual restored PVC names (which may differ from original names)
+	// Populate the actual restored PVC names and volumeMode (which may differ from original names)
+	// We need to query volumeMode to determine whether to use volumeMounts (Filesystem)
+	// or volumeDevices (Block) when mounting PVCs in the pod spec
 	for i := range pvcMounts {
 		restoredName, err := r.findRestoredPVCName(ctx, restoreNamespace, pvcMounts[i].VeleroRestoreName, pvcMounts[i].PVCName)
 		if err != nil {
 			return fmt.Errorf("failed to find restored PVC name for %s: %w", pvcMounts[i].PVCName, err)
 		}
 		pvcMounts[i].RestoredPVCName = restoredName
-		logger.V(1).Info("Resolved PVC name for file server",
+
+		// Query PVC to get its volumeMode
+		pvc := &corev1.PersistentVolumeClaim{}
+		err = r.Get(ctx, types.NamespacedName{
+			Name:      restoredName,
+			Namespace: restoreNamespace,
+		}, pvc)
+		if err != nil {
+			return fmt.Errorf("failed to get PVC %s to query volumeMode: %w", restoredName, err)
+		}
+
+		// Store volumeMode (defaults to Filesystem if not specified)
+		if pvc.Spec.VolumeMode != nil {
+			pvcMounts[i].VolumeMode = pvc.Spec.VolumeMode
+		} else {
+			// Default to Filesystem if not specified (per K8s API defaults)
+			defaultMode := corev1.PersistentVolumeFilesystem
+			pvcMounts[i].VolumeMode = &defaultMode
+		}
+
+		logger.V(1).Info("Resolved PVC info for file server",
 			"originalName", pvcMounts[i].PVCName,
-			"restoredName", restoredName)
+			"restoredName", restoredName,
+			"volumeMode", *pvcMounts[i].VolumeMode)
 	}
 
 	logger.V(0).Info("Creating file server resources",
@@ -2480,134 +2546,156 @@ func (r *VirtualMachineFileRestoreReconciler) createFileServerResources(
 	// TODO: Re-enable SSH/FileBrowser sidecars after Increment 1 is complete
 	// For now, commenting out to focus on core file server functionality
 	/*
-	// Configure SSH access if enabled
-	if vmfr.Spec.FileAccess != nil && vmfr.Spec.FileAccess.SSH != nil {
-		sshSpec := vmfr.Spec.FileAccess.SSH
+		// Configure SSH access if enabled
+		if vmfr.Spec.FileAccess != nil && vmfr.Spec.FileAccess.SSH != nil {
+			sshSpec := vmfr.Spec.FileAccess.SSH
 
-		// Determine username (default: constant.DefaultSSHUsername = "oadp")
-		username := sshSpec.Username
-		if username == "" {
-			username = constant.DefaultSSHUsername
-		}
-
-		// Use default SSH port
-		port := int32(constant.DefaultSSHPort)
-
-		// Determine which secret to use based on how credentials were provided
-		// (ensureCredentials() already validated/copied/generated as needed)
-		if sshSpec.CredentialsSecretRef != nil {
-			// Scenario 1: User provided CredentialsSecretRef
-			// Secret may be in restore namespace (original) or copied
-			secretName := sshSpec.CredentialsSecretRef.Name
-			secretNamespace := sshSpec.CredentialsSecretRef.Namespace
-			if secretNamespace == "" {
-				secretNamespace = r.OADPNamespace
+			// Determine username (default: constant.DefaultSSHUsername = "oadp")
+			username := sshSpec.Username
+			if username == "" {
+				username = constant.DefaultSSHUsername
 			}
 
-			// Determine actual secret name in restore namespace
-			var actualSecretName string
-			var err error
-			if secretNamespace == restoreNamespace {
-				// Secret was already in restore namespace, use original name
-				actualSecretName = secretName
+			// Use default SSH port
+			port := int32(constant.DefaultSSHPort)
+
+			// Handle three credential scenarios:
+			// 1. Secret reference provided
+			// 2. Inline publicKey provided
+			// 3. Neither (generate credentials)
+			if sshSpec.CredentialsSecretRef != nil {
+				// Scenario 1: Use existing Secret
+				secretName := sshSpec.CredentialsSecretRef.Name
+				secretNamespace := sshSpec.CredentialsSecretRef.Namespace
+				if secretNamespace == "" {
+					secretNamespace = vmfr.Namespace
+				}
+
+				// Validate that secret exists
+				secret := &corev1.Secret{}
+				if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: secretNamespace}, secret); err != nil {
+					return fmt.Errorf("failed to get SSH credentials secret %s/%s: %w", secretNamespace, secretName, err)
+				}
+
+				logger.V(0).Info("Using existing SSH credentials secret", "secretName", secretName, "secretNamespace", secretNamespace)
+
+				sshConfig = &SSHAccessConfig{
+					Username:                   username,
+					PublicKey:                  "", // Will be read from secret
+					CredentialsSecretName:      secretName,
+					CredentialsSecretNamespace: secretNamespace,
+					Port:                       port,
+				}
+			} else if sshSpec.PublicKey != "" {
+				// Scenario 2: Inline publicKey
+				logger.V(0).Info("Using inline SSH public key", "username", username)
+
+				sshConfig = &SSHAccessConfig{
+					Username:  username,
+					PublicKey: sshSpec.PublicKey,
+					Port:      port,
+				}
 			} else {
-				// Secret was copied - look it up by labels
-				actualSecretName, err = r.findSecretByLabels(ctx, restoreNamespace, string(vmfr.UID), constant.CredentialTypeSSH, true)
+				// Scenario 3: Generate SSH keypair and create secret
+				logger.V(0).Info("Generating SSH keypair (no publicKey or secret provided)", "username", username)
+
+				keyPair, err := function.GenerateSSHKeyPair(logger)
 				if err != nil {
-					return fmt.Errorf("failed to find copied SSH secret: %w", err)
+					return fmt.Errorf("failed to generate SSH keypair: %w", err)
+				}
+
+				// Create secret with generated credentials in restore namespace
+				secretName := fmt.Sprintf("%s-ssh-creds", vmfr.Name)
+				secret := function.CreateSSHCredentialsSecret(
+					secretName,
+					restoreNamespace,
+					username,
+					keyPair,
+					vmfr.Name,
+					vmfr.Namespace,
+					vmfr.UID,
+					logger,
+				)
+
+				if err := r.Create(ctx, secret); err != nil && !apierrors.IsAlreadyExists(err) {
+					return fmt.Errorf("failed to create SSH credentials secret: %w", err)
+				}
+
+				logger.V(0).Info("Created SSH credentials secret", "secretName", secretName, "namespace", restoreNamespace)
+
+				sshConfig = &SSHAccessConfig{
+					Username:                   username,
+					PublicKey:                  "", // Will be read from secret
+					CredentialsSecretName:      secretName,
+					CredentialsSecretNamespace: restoreNamespace,
+					Port:                       port,
 				}
 			}
-
-			logger.V(1).Info("Using prepared SSH secret",
-				"secretName", actualSecretName,
-				"namespace", restoreNamespace)
-
-			sshConfig = &SSHAccessConfig{
-				Username:                   username,
-				CredentialsSecretName:      actualSecretName,
-				CredentialsSecretNamespace: restoreNamespace,
-				Port:                       port,
-			}
-		} else {
-			// Scenario 2 & 3: Inline publicKey or generated credentials - look up by labels
-			// Both scenarios now create secrets in ensureCredentials()
-			actualSecretName, err := r.findSecretByLabels(ctx, restoreNamespace, string(vmfr.UID), constant.CredentialTypeSSH, false)
-			if err != nil {
-				return fmt.Errorf("failed to find SSH secret: %w", err)
-			}
-
-			logger.V(1).Info("Using SSH secret",
-				"secretName", actualSecretName,
-				"namespace", restoreNamespace)
-
-			sshConfig = &SSHAccessConfig{
-				Username:                   username,
-				CredentialsSecretName:      actualSecretName,
-				CredentialsSecretNamespace: restoreNamespace,
-				Port:                       port,
-			}
 		}
-	}
 
-	// Configure FileBrowser access if enabled
-	if vmfr.Spec.FileAccess != nil && vmfr.Spec.FileAccess.FileBrowser != nil {
-		fbSpec := vmfr.Spec.FileAccess.FileBrowser
+		// Configure FileBrowser access if enabled
+		if vmfr.Spec.FileAccess != nil && vmfr.Spec.FileAccess.FileBrowser != nil {
+			fbSpec := vmfr.Spec.FileAccess.FileBrowser
 
-		// Use default FileBrowser port
-		port := int32(constant.DefaultFileBrowserPort)
+			// Use default FileBrowser port
+			port := int32(constant.DefaultFileBrowserPort)
 
-		// Determine which secret to use
-		// (ensureCredentials() already validated/copied/generated as needed)
-		if fbSpec.CredentialsSecretRef != nil {
-			// Scenario 1: User provided CredentialsSecretRef
-			// Secret may be in restore namespace (original) or copied
-			secretName := fbSpec.CredentialsSecretRef.Name
-			secretNamespace := fbSpec.CredentialsSecretRef.Namespace
-			if secretNamespace == "" {
-				secretNamespace = r.OADPNamespace
-			}
+			// Handle credentials: either from secret or generated
+			if fbSpec.CredentialsSecretRef != nil {
+				// Use existing Secret
+				secretName := fbSpec.CredentialsSecretRef.Name
+				secretNamespace := fbSpec.CredentialsSecretRef.Namespace
+				if secretNamespace == "" {
+					secretNamespace = vmfr.Namespace
+				}
 
-			// Determine actual secret name in restore namespace
-			var actualSecretName string
-			var err error
-			if secretNamespace == restoreNamespace {
-				// Secret was already in restore namespace, use original name
-				actualSecretName = secretName
+				// Validate that secret exists
+				secret := &corev1.Secret{}
+				if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: secretNamespace}, secret); err != nil {
+					return fmt.Errorf("failed to get FileBrowser credentials secret %s/%s: %w", secretNamespace, secretName, err)
+				}
+
+				logger.V(0).Info("Using existing FileBrowser credentials secret", "secretName", secretName, "secretNamespace", secretNamespace)
+
+				fileBrowserConfig = &FileBrowserAccessConfig{
+					CredentialsSecretName:      secretName,
+					CredentialsSecretNamespace: secretNamespace,
+					Port:                       port,
+				}
 			} else {
-				// Secret was copied - look it up by labels
-				actualSecretName, err = r.findSecretByLabels(ctx, restoreNamespace, string(vmfr.UID), constant.CredentialTypeFileBrowser, true)
+				// Generate FileBrowser credentials and create secret
+				logger.V(0).Info("Generating FileBrowser credentials (no secret provided)")
+
+				credentials, err := function.GenerateFileBrowserCredentials("", logger) // Use default username
 				if err != nil {
-					return fmt.Errorf("failed to find copied FileBrowser secret: %w", err)
+					return fmt.Errorf("failed to generate FileBrowser credentials: %w", err)
+				}
+
+				// Create secret with generated credentials in restore namespace
+				secretName := fmt.Sprintf("%s-filebrowser-creds", vmfr.Name)
+				secret := function.CreateFileBrowserCredentialsSecret(
+					secretName,
+					restoreNamespace,
+					credentials,
+					vmfr.Name,
+					vmfr.Namespace,
+					vmfr.UID,
+					logger,
+				)
+
+				if err := r.Create(ctx, secret); err != nil && !apierrors.IsAlreadyExists(err) {
+					return fmt.Errorf("failed to create FileBrowser credentials secret: %w", err)
+				}
+
+				logger.V(0).Info("Created FileBrowser credentials secret", "secretName", secretName, "namespace", restoreNamespace, "username", credentials.Username)
+
+				fileBrowserConfig = &FileBrowserAccessConfig{
+					CredentialsSecretName:      secretName,
+					CredentialsSecretNamespace: restoreNamespace,
+					Port:                       port,
 				}
 			}
-
-			logger.V(1).Info("Using prepared FileBrowser secret",
-				"secretName", actualSecretName,
-				"namespace", restoreNamespace)
-
-			fileBrowserConfig = &FileBrowserAccessConfig{
-				CredentialsSecretName:      actualSecretName,
-				CredentialsSecretNamespace: restoreNamespace,
-				Port:                       port,
-			}
-		} else {
-			// Scenario 2: Generated credentials - look up by labels
-			actualSecretName, err := r.findSecretByLabels(ctx, restoreNamespace, string(vmfr.UID), constant.CredentialTypeFileBrowser, false)
-			if err != nil {
-				return fmt.Errorf("failed to find generated FileBrowser secret: %w", err)
-			}
-
-			logger.V(1).Info("Using generated FileBrowser secret",
-				"secretName", actualSecretName,
-				"namespace", restoreNamespace)
-
-			fileBrowserConfig = &FileBrowserAccessConfig{
-				CredentialsSecretName:      actualSecretName,
-				CredentialsSecretNamespace: restoreNamespace,
-				Port:                       port,
-			}
 		}
-	}
 	*/
 
 	// Build pod configuration with parsed access methods
@@ -2694,6 +2782,7 @@ func (r *VirtualMachineFileRestoreReconciler) createFileServerResources(
 	return nil
 }
 
+<<<<<<< HEAD
 // ensureSecretInRestoreNamespace ensures a secret is available in the restore namespace.
 // If the secret is already in the restore namespace, it validates and returns the secret name.
 // If the secret is in a different namespace, it validates the source, copies it to the restore
@@ -3116,6 +3205,186 @@ func (r *VirtualMachineFileRestoreReconciler) ensureCredentials(
 
 	logger.V(0).Info("All credentials ready for file server creation")
 	return nil
+=======
+// fixDataDownloadPVCNames fixes the DataDownload PVC name mismatch issue caused by kubevirt-velero-plugin.
+// When using Velero Data Mover with kubevirt-velero-plugin, there's a mismatch between the PVC name
+// in the DataDownload spec and the actual restored PVC name:
+// - kubevirt-velero-plugin modifies PVC names during restore (adds backup name prefix + suffix)
+// - But DataDownload is created with the original PVC name in spec.targetVolume.pvc
+// - DataDownload controller can't find the PVC and gets stuck
+//
+// This function:
+// 1. Lists DataDownload resources created by our Velero Restores (using VMFR UID label)
+// 2. For each DataDownload with empty/pending status (not started):
+//    - Finds the corresponding Velero Restore from annotations
+//    - Finds the actual restored PVC name by listing PVCs with velero.io/restore-name label
+//    - Matches PVC by original name annotation (constant.VMFROriginalPVCNameAnnotation)
+//    - Patches DataDownload spec.targetVolume.pvc with the actual PVC name
+//
+// Returns the count of DataDownloads that were patched.
+func (r *VirtualMachineFileRestoreReconciler) fixDataDownloadPVCNames(
+	ctx context.Context,
+	logger logr.Logger,
+	vmfr *oadpv1alpha1.VirtualMachineFileRestore,
+) (int, error) {
+
+	// Get restore namespace where PVCs were created
+	restoreNamespace := vmfr.Status.CreatedNamespace
+	if restoreNamespace == "" {
+		logger.V(1).Info("Restore namespace not yet created, skipping DataDownload fix")
+		return 0, nil
+	}
+
+	// IMPORTANT: Velero creates DataDownload resources WITHOUT our custom VMFR UID label
+	// We can't list DataDownloads directly by VMFR UID. Instead, we need to:
+	// 1. First list Velero Restores created by this VMFR (they DO have our VMFR UID label)
+	// 2. Then find DataDownloads associated with those Velero Restores (via velero.io/restore-name label)
+
+	// Step 1: List all Velero Restores owned by this VMFR
+	restoreList := &veleroapi.RestoreList{}
+	restoreListOpts := []client.ListOption{
+		client.InNamespace(r.OADPNamespace),
+		client.MatchingLabels{
+			constant.VMFROriginUUIDLabel: string(vmfr.UID),
+		},
+	}
+
+	if err := r.List(ctx, restoreList, restoreListOpts...); err != nil {
+		logger.Error(err, "Failed to list Velero Restores for DataDownload lookup")
+		return 0, fmt.Errorf("failed to list Velero Restores: %w", err)
+	}
+
+	if len(restoreList.Items) == 0 {
+		logger.V(1).Info("No Velero Restores found for this VMFR, no DataDownloads to fix")
+		return 0, nil
+	}
+
+	logger.V(1).Info("Found Velero Restores for VMFR", "count", len(restoreList.Items))
+
+	// Step 2: For each Velero Restore, find associated DataDownloads
+	var dataDownloads []veleroapiv2alpha1.DataDownload
+	for _, restore := range restoreList.Items {
+		// List DataDownloads for this specific Velero Restore using velero.io/restore-name label
+		ddList := &veleroapiv2alpha1.DataDownloadList{}
+		ddListOpts := []client.ListOption{
+			client.InNamespace(r.OADPNamespace),
+			client.MatchingLabels{
+				"velero.io/restore-name": restore.Name,
+			},
+		}
+
+		if err := r.List(ctx, ddList, ddListOpts...); err != nil {
+			logger.Error(err, "Failed to list DataDownloads for Velero Restore", "restoreName", restore.Name)
+			continue // Continue with other restores even if one fails
+		}
+
+		dataDownloads = append(dataDownloads, ddList.Items...)
+	}
+
+	if len(dataDownloads) == 0 {
+		logger.V(1).Info("No DataDownload resources found for this VMFR's Velero Restores")
+		return 0, nil
+	}
+
+	logger.V(0).Info("Found DataDownload resources", "count", len(dataDownloads))
+
+	fixedCount := 0
+	for i := range dataDownloads {
+		dataDownload := &dataDownloads[i]
+
+		// Only process DataDownloads that haven't started yet
+		// Status.Phase is empty or "New" when DataDownload hasn't started
+		if dataDownload.Status.Phase != "" && dataDownload.Status.Phase != "New" {
+			logger.V(1).Info("DataDownload already in progress, skipping",
+				"name", dataDownload.Name,
+				"phase", dataDownload.Status.Phase)
+			continue
+		}
+
+		// Get the Velero Restore name from DataDownload owner references or labels
+		// DataDownload is owned by the Velero Restore that created it
+		veleroRestoreName := ""
+		for _, ownerRef := range dataDownload.OwnerReferences {
+			if ownerRef.Kind == "Restore" && ownerRef.APIVersion == "velero.io/v1" {
+				veleroRestoreName = ownerRef.Name
+				break
+			}
+		}
+
+		if veleroRestoreName == "" {
+			logger.V(1).Info("DataDownload has no Velero Restore owner reference, skipping",
+				"name", dataDownload.Name)
+			continue
+		}
+
+		// Get the original PVC name from DataDownload spec
+		originalPVCName := dataDownload.Spec.TargetVolume.PVC
+		if originalPVCName == "" {
+			logger.V(1).Info("DataDownload has no target PVC name, skipping",
+				"name", dataDownload.Name)
+			continue
+		}
+
+		logger.V(1).Info("Processing DataDownload",
+			"name", dataDownload.Name,
+			"veleroRestore", veleroRestoreName,
+			"originalPVCName", originalPVCName)
+
+		// Find the actual restored PVC name
+		actualPVCName, err := r.findRestoredPVCName(ctx, restoreNamespace, veleroRestoreName, originalPVCName)
+		if err != nil {
+			logger.V(1).Info("PVC not yet created for DataDownload, will retry later",
+				"dataDownload", dataDownload.Name,
+				"originalPVCName", originalPVCName,
+				"veleroRestore", veleroRestoreName,
+				"error", err.Error())
+			// Don't treat this as a hard error - PVC might not be created yet
+			continue
+		}
+
+		// Check if PVC name needs updating
+		if actualPVCName == originalPVCName {
+			logger.V(1).Info("DataDownload PVC name already correct, no patch needed",
+				"name", dataDownload.Name,
+				"pvcName", actualPVCName)
+			continue
+		}
+
+		logger.V(0).Info("Patching DataDownload with correct PVC name",
+			"dataDownload", dataDownload.Name,
+			"originalPVCName", originalPVCName,
+			"actualPVCName", actualPVCName)
+
+		// Patch the DataDownload with the actual PVC name
+		// Use JSON patch to update spec.targetVolume.pvc field
+		patch := client.RawPatch(
+			types.JSONPatchType,
+			[]byte(fmt.Sprintf(`[{"op": "replace", "path": "/spec/targetVolume/pvc", "value": "%s"}]`, actualPVCName)),
+		)
+
+		if err := r.Patch(ctx, dataDownload, patch); err != nil {
+			logger.Error(err, "Failed to patch DataDownload",
+				"name", dataDownload.Name,
+				"originalPVCName", originalPVCName,
+				"actualPVCName", actualPVCName)
+			return fixedCount, fmt.Errorf("failed to patch DataDownload %s: %w", dataDownload.Name, err)
+		}
+
+		fixedCount++
+		logger.V(0).Info("Successfully patched DataDownload",
+			"name", dataDownload.Name,
+			"originalPVCName", originalPVCName,
+			"actualPVCName", actualPVCName)
+	}
+
+	if fixedCount > 0 {
+		logger.V(0).Info("DataDownload PVC name fix completed",
+			"totalDataDownloads", len(dataDownloads),
+			"fixedCount", fixedCount)
+	}
+
+	return fixedCount, nil
+>>>>>>> d832fcc (Add Block mode PVC support and DataDownload PVC name auto-fix)
 }
 
 // handleVeleroRestoreCleanup deletes Velero Restore objects created by this VMFR.

--- a/internal/controller/virtualmachinefilerestore_controller.go
+++ b/internal/controller/virtualmachinefilerestore_controller.go
@@ -2706,11 +2706,11 @@ func (r *VirtualMachineFileRestoreReconciler) createFileServerResources(
 		VMFRNamespace:        vmfr.Namespace,
 		VMFRUID:              string(vmfr.UID),
 		PVCMounts:            pvcMounts,
-		MainContainer:        ptr.To(buildVMFileServerMainContainer()), // Use VM file server for disk mounting
-		SSHAccess:            sshConfig,                                // Configured SSH access (or nil)
-		FileBrowserAccess:    fileBrowserConfig,                        // Configured FileBrowser access (or nil)
-		EnableDualPathAccess: true,                                     // Enable dual-path symlinks
-		UseInternalMounts:    false,                                    // Use Kubernetes-managed PVC mounts
+		MainContainer:        ptr.To(buildVMFileServerMainContainer(pvcMounts)), // Use VM file server for disk mounting
+		SSHAccess:            sshConfig,                                          // Configured SSH access (or nil)
+		FileBrowserAccess:    fileBrowserConfig,                                  // Configured FileBrowser access (or nil)
+		EnableDualPathAccess: true,                                               // Enable dual-path symlinks
+		UseInternalMounts:    false,                                              // Use Kubernetes-managed PVC mounts
 	}
 
 	logger.V(0).Info("File server configuration prepared",


### PR DESCRIPTION
## Summary
This PR implements the complete file server pod infrastructure with critical fixes for VM disk restore using Velero Data Mover. It enables privileged SCC support for QEMU/libguestfs VM disk mounting, resolves Block mode PVC support, fixes dual-path directory structure, and patches DataDownload PVC name mismatches.

## What's Changed

### 1. VM File Server Container Implementation
- Adds specialized container using `oadp-vm-file-server` image with libguestfs and guestmount
- Configures privileged mode for `/dev/kvm` and `/dev/fuse` device access
- Sets up proper user/group permissions (qemu UID 107) with fsGroup
- Implements SELinux spc_t type to disable volume relabeling
- Mounts required devices: `/dev/kvm` (KVM acceleration), `/dev/fuse` (FUSE filesystem)
- Runs `detect-and-mount.sh` to automatically mount VM disk images

### 2. Block Mode PVC Support (CRITICAL FIX)
**Problem**: File server pods failed to start with error: `volumeMode Block, but is specified in volumeMounts`

**Root Cause**: OpenShift Virtualization VMs use Block mode PVCs for VM disks (raw block devices), but controller was incorrectly using `volumeMounts` (only for Filesystem mode).

**Solution Implemented**:
- Added `VolumeMode` field to `PVCMountInfo` struct to track PVC volume mode
- Updated `buildPVCVolumesAndMounts()` to handle both PVC types correctly:
  - **Block mode PVCs**: Use `volumeDevices` with device path `/dev/pvc-{uid}` (raw block device access)
  - **Filesystem mode PVCs**: Use `volumeMounts` with mount path `/restores_by_name/{backup}/{uid}`
- Query PVC `spec.volumeMode` in `createFileServerResources()` before building pod spec
- Populates `RestoredPVCName` and `VolumeMode` for each PVC mount
- Updated `detect-and-mount.sh` to detect and mount Block mode PVCs from `/dev/pvc-*` devices

**Impact**: File server pods now start successfully with Block mode VM disk PVCs ✅

### 3. Dual-Path Directory Structure Fix (CRITICAL FIX)
**Problem**: `/restores_by_name` worked correctly but `/restores_by_date` was empty due to conflicting directory creation methods:
- `/restores_by_name` created by file server script (worked)
- `/restores_by_date` mounted as read-only EmptyDir volume by controller (failed)
- Script logs showed: `mkdir: cannot create directory '/restores_by_date/2025-10-23': Read-only file system`

**Solution - Uniform Handling**:
Both `/restores_by_name` and `/restores_by_date` are now created uniformly by the file server script at runtime, removing all controller-managed volume handling.

**Changes Made**:
- Removed EmptyDir volume creation for "restores-by-date" from controller
- Removed dual-path init container that created symlinks
- Removed `/restores_by_date` volumeMount from all containers (main, SSH, FileBrowser)
- Added `buildBackupPVCMapJSON()` to generate BACKUP_PVC_MAP environment variable
- Updated `detect-and-mount.sh` with `create_dual_path_structure()` function
- Script now creates both directory structures after filesystem mounting:
  - `/restores_by_name/{backup-name}/{pvc-name}` → `/mnt/filesystems/{backup}/{pvc}/`
  - `/restores_by_date/{date}/{pvc-name}` → `/restores_by_name/{backup}/{pvc}`

**Impact**: Both browsing paths are now functional for file recovery ✅

### 4. DataDownload PVC Name Mismatch Auto-Fix (CRITICAL FIX)
**Problem**: Velero Data Mover restores were stuck indefinitely when using kubevirt-velero-plugin because:
- kubevirt-velero-plugin renames PVCs during restore (adds backup name prefix + suffix)
- Example: `test-vm-rootdisk` → `vm-backup-test-vm-rootdisk-abc123`
- But DataDownload resource is created with original PVC name in `spec.targetVolume.pvc`
- DataDownload controller cannot find the PVC and gets stuck with no progress

**Solution Implemented**:
- Added `fixDataDownloadPVCNames()` function to automatically patch DataDownload resources
- Uses two-tier lookup strategy (Velero doesn't add our VMFR UID label to DataDownloads):
  1. List Velero Restore resources by VMFR UID label
  2. Find DataDownload resources for each Velero Restore via `velero.io/restore-name` label
- For DataDownloads with empty/pending status (not started):
  - Finds actual restored PVC name by listing PVCs with `velero.io/restore-name` label
  - Matches PVC by original name annotation (`oadp.openshift.io/vmfr-original-pvc-name`)
  - Patches DataDownload `spec.targetVolume.pvc` with actual PVC name using JSON patch
- Called in `WaitingForRestores` phase during Velero Restore monitoring
- Returns count of fixed DataDownloads for logging

**Impact**: Data Mover restores now complete automatically without manual intervention ✅

### 5. Scheme Registration and RBAC for DataDownload
- Registered `velero/v2alpha1` scheme in `cmd/main.go` to enable DataDownload API access
- Added RBAC permissions for `datadownloads` resources: `get`, `list`, `watch`, `patch`
- Enables controller to query and patch DataDownload resources

### 6. ServiceAccount and SCC Binding
- Programmatically creates `vmfr-file-server` ServiceAccount in each restore namespace
- Creates RoleBinding to bind ServiceAccount to `system:openshift:scc:privileged`
- Uses namespace-scoped RoleBinding (not cluster-wide) for security isolation
- Implements ownership tracking via labels (no cross-namespace owner references)

### 7. RBAC Permissions
- Adds kubebuilder RBAC markers for `serviceaccounts`, `rolebindings`, and `datadownloads` resources
- Regenerates ClusterRole with required permissions using `make manifests`
- Enables controller to create ServiceAccount, bind to privileged SCC, and manage DataDownloads

### 8. Supporting Utilities
- Adds SSH credential generation functions (ED25519 keypair)
- Adds FileBrowser credential generation (for future sidecars)
- Adds Secret creation helpers with proper labeling

### 9. Container Image Updates
- Updated VMFileServerImage to `quay.io/spampatt/oadp-vm-file-server:dual-path-fix`
- Updated controller image to `quay.io/spampatt/oadp-vm-file-restore:latest`

## Why Privileged SCC?
File server pods require privileged SCC for:
- **hostPath volumes**: Access to `/dev/kvm` and `/dev/fuse` devices
- **Privileged containers**: Required for device access with SELinux enforcing
- **Custom SELinux type**: spc_t to disable volume relabeling for VM disk PVCs
- **KVM acceleration**: Hardware virtualization for efficient disk image mounting
- **Block device access**: Direct access to VM disk block devices at `/dev/pvc-{uid}`

## Security Considerations
✅ Each VMFR gets isolated namespace with dedicated ServiceAccount  
✅ RoleBinding is namespace-scoped (not cluster-wide)  
✅ Temporary namespace deleted when VMFR is deleted (cascade cleanup)  
✅ No cross-namespace privilege escalation possible  

## Testing Performed

### Block Mode PVC Support
✅ Created test VM with 10GB qcow2 disk (Block mode PVC)  
✅ Backed up VM using Velero with Data Mover enabled  
✅ Created VirtualMachineFileRestore resource  
✅ File server pod starts successfully (1/1 Running) - no volumeMount errors  
✅ Block device accessible at `/dev/pvc-{uid}`  
✅ Pod spec correctly uses `volumeDevices` instead of `volumeMounts`  
✅ Script successfully detects and mounts Block mode PVCs  

### Dual-Path Directory Structure
✅ Verified `/restores_by_name/test-vm-backup-20250115/test-vm-disk-1` exists  
✅ Verified `/restores_by_date/2025-10-23/test-vm-disk-1` exists  
✅ Confirmed symlinks point to correct mount points  
✅ Validated VM filesystem files are browsable via both paths  
✅ No "Read-only file system" errors in pod logs  
✅ Both directories created uniformly by script  

### DataDownload Auto-Fix
✅ DataDownload PVC name automatically patched from `test-vm-data-rootdisk` to `vm-test-data-backup-test-vm-data-rootdisk-pzllc`  
✅ Controller logs show: "Successfully patched DataDownload" with correct PVC names  
✅ DataDownload completed successfully: STATUS=Completed, 10737418240 bytes (10GB)  
✅ Velero Restore progressed from WaitingForPluginOperations to Completed  
✅ VMFR reached Completed phase with file server available  

### General Functionality
✅ VMFR reaches "Completed" phase successfully  
✅ ServiceAccount `vmfr-file-server` created in restore namespace  
✅ RoleBinding to privileged SCC created successfully  
✅ File server pod runs without SCC permission errors  
✅ PVCs mounted successfully with proper access  
✅ No "hostPath volumes are not allowed" errors  
✅ No "cannot use security context constraint 'privileged'" errors  
✅ BACKUP_PVC_MAP environment variable correctly passed to container  

## Technical Details

### PVC Volume Mode Handling
```go
// Block mode PVC - uses volumeDevices
volumeDevices = append(volumeDevices, corev1.VolumeDevice{
    Name:       volumeName,
    DevicePath: "/dev/pvc-{uid}",  // Raw block device
})

// Filesystem mode PVC - uses volumeMounts
volumeMounts = append(volumeMounts, corev1.VolumeMount{
    Name:      volumeName,
    MountPath: "/restores_by_name/{backup}/{uid}",
    ReadOnly:  false,  // libguestfs needs write access
})
```

### Dual-Path Structure Creation
```bash
# Script creates both directories uniformly
/restores_by_name/{backup-name}/{pvc-name} -> /mnt/filesystems/{backup}/{pvc}/
/restores_by_date/{date}/{pvc-name} -> /restores_by_name/{backup}/{pvc}
```

### BACKUP_PVC_MAP Format
```json
{
  "test-vm-backup-20250115": [
    {
      "name": "test-vm-disk-1",
      "path": "/dev/pvc-5685cd9a-56b4-4482-9236-17b7cc4b0dff",
      "timestamp": "2025-10-23T18:40:00Z"
    }
  ]
}
```

### DataDownload Fix Flow
1. Monitor Velero Restores in `WaitingForRestores` phase
2. For each Velero Restore, list associated DataDownloads via `velero.io/restore-name` label
3. For DataDownloads with status="" or "New":
   - Find restored PVC by listing with `velero.io/restore-name` label
   - Match PVC using `oadp.openshift.io/vmfr-original-pvc-name` annotation
   - Patch DataDownload `spec.targetVolume.pvc` with actual PVC name
4. DataDownload controller proceeds with correct PVC reference

## Commits in this PR
1. `2e2f09d` - Add VM file server container with privileged mode and device mounts
2. `7fb3a29` - Add ServiceAccount creation with privileged SCC binding
3. `710d5b8` - Add RBAC permissions for ServiceAccount and RoleBinding resources
4. `03a064f` - Update container image to development version
5. `5a1eafc` - Add SSH credential generation utilities for future use
6. `d832fcc` - Add Block mode PVC support and DataDownload PVC name auto-fix
7. `c4892ba` - Add Block mode PVC support and fix dual-path directory structure

## Related Issues
- Implements core functionality for Issue #6 and Issue #7 (Pod lifecycle and file server)
- Resolves Block mode PVC mounting errors for OpenShift Virtualization VMs
- Fixes Velero Data Mover restore blocking issue with kubevirt-velero-plugin
- Fixes dual-path directory structure inconsistency for file browsing

## Next Steps
- Add support for SSH and FileBrowser sidecars (utilities already implemented)
- Test with multiple backups and PVCs
- Document user-facing file browsing workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
