### PR TITLE
Fix DataDownload PVC name discovery to use Labels instead of Annotations

### DIFF
--- a/internal/controller/virtualmachinefilerestore_controller.go
+++ b/internal/controller/virtualmachinefilerestore_controller.go
@@ -2703,10 +2703,10 @@ func (r *VirtualMachineFileRestoreReconciler) findRestoredPVCName(
 		return "", fmt.Errorf("failed to list PVCs for restore %s: %w", veleroRestoreName, err)
 	}
 
-	// Filter by annotation to find the PVC with the matching original name
+	// Filter by label to find the PVC with the matching original name
 	for i := range pvcList.Items {
-		if pvcList.Items[i].Annotations != nil {
-			if origName := pvcList.Items[i].Annotations[constant.VMFROriginalPVCNameAnnotation]; origName == originalPVCName {
+		if pvcList.Items[i].Labels != nil {
+			if origName := pvcList.Items[i].Labels[constant.VMFROriginalPVCNameAnnotation]; origName == originalPVCName {
 				return pvcList.Items[i].Name, nil
 			}
 		}

--- a/internal/controller/virtualmachinefilerestore_controller_test.go
+++ b/internal/controller/virtualmachinefilerestore_controller_test.go
@@ -974,9 +974,9 @@ func TestFindRestoredPVCName(t *testing.T) {
 						Name:      "restored-pvc-abc123",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "test-restore",
-						constant.VMFROriginalPVCNameAnnotation: "original-pvc-name",
-					},
+							"velero.io/restore-name":               "test-restore",
+							constant.VMFROriginalPVCNameAnnotation: "original-pvc-name",
+						},
 					},
 				},
 			},
@@ -1003,9 +1003,9 @@ func TestFindRestoredPVCName(t *testing.T) {
 						Name:      "wrong-restore-pvc",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "different-restore",
-						constant.VMFROriginalPVCNameAnnotation: "original-pvc-name",
-					},
+							"velero.io/restore-name":               "different-restore",
+							constant.VMFROriginalPVCNameAnnotation: "original-pvc-name",
+						},
 					},
 				},
 			},
@@ -1023,9 +1023,9 @@ func TestFindRestoredPVCName(t *testing.T) {
 						Name:      "wrong-annotation-pvc",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "test-restore",
-						constant.VMFROriginalPVCNameAnnotation: "different-pvc-name",
-					},
+							"velero.io/restore-name":               "test-restore",
+							constant.VMFROriginalPVCNameAnnotation: "different-pvc-name",
+						},
 					},
 				},
 			},
@@ -1063,9 +1063,9 @@ func TestFindRestoredPVCName(t *testing.T) {
 						Name:      "pvc-1",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "test-restore",
-						constant.VMFROriginalPVCNameAnnotation: "other-pvc",
-					},
+							"velero.io/restore-name":               "test-restore",
+							constant.VMFROriginalPVCNameAnnotation: "other-pvc",
+						},
 					},
 				},
 				{
@@ -1073,9 +1073,9 @@ func TestFindRestoredPVCName(t *testing.T) {
 						Name:      "pvc-2",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "test-restore",
-						constant.VMFROriginalPVCNameAnnotation: "target-pvc",
-					},
+							"velero.io/restore-name":               "test-restore",
+							constant.VMFROriginalPVCNameAnnotation: "target-pvc",
+						},
 					},
 				},
 				{
@@ -1083,9 +1083,9 @@ func TestFindRestoredPVCName(t *testing.T) {
 						Name:      "pvc-3",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "test-restore",
-						constant.VMFROriginalPVCNameAnnotation: "another-pvc",
-					},
+							"velero.io/restore-name":               "test-restore",
+							constant.VMFROriginalPVCNameAnnotation: "another-pvc",
+						},
 					},
 				},
 			},
@@ -2461,9 +2461,9 @@ func TestFixDataDownloadPVCNames(t *testing.T) {
 						Name:      "original-pvc",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "velero-restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "original-pvc",
-					},
+							"velero.io/restore-name":               "velero-restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "original-pvc",
+						},
 					},
 				},
 			},
@@ -2522,9 +2522,9 @@ func TestFixDataDownloadPVCNames(t *testing.T) {
 						Name:      "restored-pvc-xyz123",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "velero-restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "original-pvc",
-					},
+							"velero.io/restore-name":               "velero-restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "original-pvc",
+						},
 					},
 				},
 			},
@@ -2604,9 +2604,9 @@ func TestFixDataDownloadPVCNames(t *testing.T) {
 						Name:      "restored-pvc-1-abc",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "velero-restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-					},
+							"velero.io/restore-name":               "velero-restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+						},
 					},
 				},
 				{
@@ -2614,9 +2614,9 @@ func TestFixDataDownloadPVCNames(t *testing.T) {
 						Name:      "restored-pvc-2-xyz",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "velero-restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-2",
-					},
+							"velero.io/restore-name":               "velero-restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-2",
+						},
 					},
 				},
 			},
@@ -3767,9 +3767,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-1",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-					},
+							"velero.io/restore-name":               "restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+						},
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimPending,
@@ -3814,9 +3814,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-1",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-					},
+							"velero.io/restore-name":               "restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+						},
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						VolumeName: "pv-1",
@@ -3864,9 +3864,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-1",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-					},
+							"velero.io/restore-name":               "restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+						},
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimLost,
@@ -3961,9 +3961,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-1",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-					},
+							"velero.io/restore-name":               "restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+						},
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimPending,
@@ -3974,9 +3974,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-2",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-2",
-					},
+							"velero.io/restore-name":               "restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-2",
+						},
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimBound,
@@ -4035,9 +4035,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-1",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-					},
+							"velero.io/restore-name":               "restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+						},
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimBound,
@@ -4098,9 +4098,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-1",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-					},
+							"velero.io/restore-name":               "restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+						},
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimPending,
@@ -4111,9 +4111,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-2",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-						"velero.io/restore-name": "restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-2",
-					},
+							"velero.io/restore-name":               "restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-2",
+						},
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						VolumeName: "pv-2",
@@ -7312,9 +7312,9 @@ func TestExecuteFileRestoreWorkflow(t *testing.T) {
 						Namespace: "restore-ns",
 						UID:       "pvc-uid-1",
 						Labels: map[string]string{
-						"velero.io/restore-name": "restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-					},
+							"velero.io/restore-name":               "restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+						},
 					},
 				},
 			},
@@ -7396,9 +7396,9 @@ func TestExecuteFileRestoreWorkflow(t *testing.T) {
 						Namespace: "restore-ns",
 						UID:       "pvc-uid-1",
 						Labels: map[string]string{
-						"velero.io/restore-name": "restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-					},
+							"velero.io/restore-name":               "restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+						},
 					},
 				},
 			},
@@ -7704,9 +7704,9 @@ func TestCreateFileServerResources(t *testing.T) {
 						Namespace: "restore-ns",
 						UID:       "restored-pvc-uid-1",
 						Labels: map[string]string{
-						"velero.io/restore-name": "restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-					},
+							"velero.io/restore-name":               "restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+						},
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						VolumeMode: func() *corev1.PersistentVolumeMode {
@@ -7759,9 +7759,9 @@ func TestCreateFileServerResources(t *testing.T) {
 						Namespace: "restore-ns",
 						UID:       "restored-pvc-uid-1",
 						Labels: map[string]string{
-						"velero.io/restore-name": "restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-					},
+							"velero.io/restore-name":               "restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+						},
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						VolumeMode: func() *corev1.PersistentVolumeMode {
@@ -7817,9 +7817,9 @@ func TestCreateFileServerResources(t *testing.T) {
 						Namespace: "restore-ns",
 						UID:       "restored-pvc-uid-1",
 						Labels: map[string]string{
-						"velero.io/restore-name": "restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-					},
+							"velero.io/restore-name":               "restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+						},
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						VolumeMode: func() *corev1.PersistentVolumeMode {
@@ -7901,9 +7901,9 @@ func TestCreateFileServerResources(t *testing.T) {
 						Namespace: "restore-ns",
 						UID:       "restored-pvc-uid-1",
 						Labels: map[string]string{
-						"velero.io/restore-name": "restore-1",
-						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-					},
+							"velero.io/restore-name":               "restore-1",
+							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+						},
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						VolumeMode: func() *corev1.PersistentVolumeMode {

--- a/internal/controller/virtualmachinefilerestore_controller_test.go
+++ b/internal/controller/virtualmachinefilerestore_controller_test.go
@@ -967,18 +967,16 @@ func TestFindRestoredPVCName(t *testing.T) {
 		errorContains     string
 	}{
 		{
-			name: "finds PVC by restore label and annotation",
+			name: "finds PVC by restore label and original name label",
 			existingPVCs: []*corev1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "restored-pvc-abc123",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "test-restore",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "original-pvc-name",
-						},
+						"velero.io/restore-name": "test-restore",
+						constant.VMFROriginalPVCNameAnnotation: "original-pvc-name",
+					},
 					},
 				},
 			},
@@ -1005,11 +1003,9 @@ func TestFindRestoredPVCName(t *testing.T) {
 						Name:      "wrong-restore-pvc",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "different-restore",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "original-pvc-name",
-						},
+						"velero.io/restore-name": "different-restore",
+						constant.VMFROriginalPVCNameAnnotation: "original-pvc-name",
+					},
 					},
 				},
 			},
@@ -1020,18 +1016,16 @@ func TestFindRestoredPVCName(t *testing.T) {
 			errorContains:     "PVC not found",
 		},
 		{
-			name: "skips PVCs with wrong annotation value",
+			name: "skips PVCs with wrong original name label value",
 			existingPVCs: []*corev1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "wrong-annotation-pvc",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "test-restore",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "different-pvc-name",
-						},
+						"velero.io/restore-name": "test-restore",
+						constant.VMFROriginalPVCNameAnnotation: "different-pvc-name",
+					},
 					},
 				},
 			},
@@ -1042,7 +1036,7 @@ func TestFindRestoredPVCName(t *testing.T) {
 			errorContains:     "PVC not found",
 		},
 		{
-			name: "skips PVCs with nil annotations",
+			name: "skips PVCs with nil labels",
 			existingPVCs: []*corev1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1069,11 +1063,9 @@ func TestFindRestoredPVCName(t *testing.T) {
 						Name:      "pvc-1",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "test-restore",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "other-pvc",
-						},
+						"velero.io/restore-name": "test-restore",
+						constant.VMFROriginalPVCNameAnnotation: "other-pvc",
+					},
 					},
 				},
 				{
@@ -1081,11 +1073,9 @@ func TestFindRestoredPVCName(t *testing.T) {
 						Name:      "pvc-2",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "test-restore",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "target-pvc",
-						},
+						"velero.io/restore-name": "test-restore",
+						constant.VMFROriginalPVCNameAnnotation: "target-pvc",
+					},
 					},
 				},
 				{
@@ -1093,11 +1083,9 @@ func TestFindRestoredPVCName(t *testing.T) {
 						Name:      "pvc-3",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "test-restore",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "another-pvc",
-						},
+						"velero.io/restore-name": "test-restore",
+						constant.VMFROriginalPVCNameAnnotation: "another-pvc",
+					},
 					},
 				},
 			},
@@ -2473,11 +2461,9 @@ func TestFixDataDownloadPVCNames(t *testing.T) {
 						Name:      "original-pvc",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "velero-restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "original-pvc",
-						},
+						"velero.io/restore-name": "velero-restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "original-pvc",
+					},
 					},
 				},
 			},
@@ -2536,11 +2522,9 @@ func TestFixDataDownloadPVCNames(t *testing.T) {
 						Name:      "restored-pvc-xyz123",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "velero-restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "original-pvc",
-						},
+						"velero.io/restore-name": "velero-restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "original-pvc",
+					},
 					},
 				},
 			},
@@ -2620,11 +2604,9 @@ func TestFixDataDownloadPVCNames(t *testing.T) {
 						Name:      "restored-pvc-1-abc",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "velero-restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-						},
+						"velero.io/restore-name": "velero-restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+					},
 					},
 				},
 				{
@@ -2632,11 +2614,9 @@ func TestFixDataDownloadPVCNames(t *testing.T) {
 						Name:      "restored-pvc-2-xyz",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "velero-restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-2",
-						},
+						"velero.io/restore-name": "velero-restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-2",
+					},
 					},
 				},
 			},
@@ -3787,11 +3767,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-1",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-						},
+						"velero.io/restore-name": "restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+					},
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimPending,
@@ -3836,11 +3814,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-1",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-						},
+						"velero.io/restore-name": "restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+					},
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						VolumeName: "pv-1",
@@ -3888,11 +3864,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-1",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-						},
+						"velero.io/restore-name": "restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+					},
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimLost,
@@ -3987,11 +3961,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-1",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-						},
+						"velero.io/restore-name": "restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+					},
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimPending,
@@ -4002,11 +3974,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-2",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-2",
-						},
+						"velero.io/restore-name": "restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-2",
+					},
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimBound,
@@ -4065,11 +4035,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-1",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-						},
+						"velero.io/restore-name": "restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+					},
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimBound,
@@ -4130,11 +4098,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-1",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-						},
+						"velero.io/restore-name": "restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+					},
 					},
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimPending,
@@ -4145,11 +4111,9 @@ func TestValidateRestoredPVCs(t *testing.T) {
 						Name:      "restored-pvc-2",
 						Namespace: "restore-ns",
 						Labels: map[string]string{
-							"velero.io/restore-name": "restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-2",
-						},
+						"velero.io/restore-name": "restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-2",
+					},
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						VolumeName: "pv-2",
@@ -7348,11 +7312,9 @@ func TestExecuteFileRestoreWorkflow(t *testing.T) {
 						Namespace: "restore-ns",
 						UID:       "pvc-uid-1",
 						Labels: map[string]string{
-							"velero.io/restore-name": "restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-						},
+						"velero.io/restore-name": "restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+					},
 					},
 				},
 			},
@@ -7434,11 +7396,9 @@ func TestExecuteFileRestoreWorkflow(t *testing.T) {
 						Namespace: "restore-ns",
 						UID:       "pvc-uid-1",
 						Labels: map[string]string{
-							"velero.io/restore-name": "restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-						},
+						"velero.io/restore-name": "restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+					},
 					},
 				},
 			},
@@ -7744,11 +7704,9 @@ func TestCreateFileServerResources(t *testing.T) {
 						Namespace: "restore-ns",
 						UID:       "restored-pvc-uid-1",
 						Labels: map[string]string{
-							"velero.io/restore-name": "restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-						},
+						"velero.io/restore-name": "restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+					},
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						VolumeMode: func() *corev1.PersistentVolumeMode {
@@ -7801,11 +7759,9 @@ func TestCreateFileServerResources(t *testing.T) {
 						Namespace: "restore-ns",
 						UID:       "restored-pvc-uid-1",
 						Labels: map[string]string{
-							"velero.io/restore-name": "restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-						},
+						"velero.io/restore-name": "restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+					},
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						VolumeMode: func() *corev1.PersistentVolumeMode {
@@ -7861,11 +7817,9 @@ func TestCreateFileServerResources(t *testing.T) {
 						Namespace: "restore-ns",
 						UID:       "restored-pvc-uid-1",
 						Labels: map[string]string{
-							"velero.io/restore-name": "restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-						},
+						"velero.io/restore-name": "restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+					},
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						VolumeMode: func() *corev1.PersistentVolumeMode {
@@ -7947,11 +7901,9 @@ func TestCreateFileServerResources(t *testing.T) {
 						Namespace: "restore-ns",
 						UID:       "restored-pvc-uid-1",
 						Labels: map[string]string{
-							"velero.io/restore-name": "restore-1",
-						},
-						Annotations: map[string]string{
-							constant.VMFROriginalPVCNameAnnotation: "pvc-1",
-						},
+						"velero.io/restore-name": "restore-1",
+						constant.VMFROriginalPVCNameAnnotation: "pvc-1",
+					},
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						VolumeMode: func() *corev1.PersistentVolumeMode {


### PR DESCRIPTION
## Summary

Fixes the DataDownload PVC name mismatch issue that was causing PVCs to remain in Pending state during Data Mover restore workflows.

## Problem

The `findRestoredPVCName` function in the VMFR controller was incorrectly checking **Annotations** for the `VMFROriginalPVCNameAnnotation` constant, but the openshift-velero-plugin VMFR plugin sets this as a **Label** (not an Annotation) when renaming PVCs.

This mismatch prevented the `fixDataDownloadPVCNames` function from finding the renamed PVC and patching the DataDownload `spec.targetVolume.pvc` field, causing DataDownload to fail with "PVC not found" errors.

## Root Cause Analysis

1. When VMFR plugin renames a PVC (e.g., `test-vm-disk-1` → `test-vm-backup-2025-10-27-test-vm-disk-1-q9l8v`), it sets:
   - **Label**: `oadp.openshift.io/vmfr-original-name: test-vm-disk-1`
   - **Label**: `oadp.openshift.io/vmfr-backup: test-vm-backup-2025-10-27`

2. The VMFR controller's `findRestoredPVCName` was checking:
   ```go
   if origName := pvcList.Items[i].Annotations[constant.VMFROriginalPVCNameAnnotation]; origName == originalPVCName {
   ```
   Instead of:
   ```go
   if origName := pvcList.Items[i].Labels[constant.VMFROriginalPVCNameAnnotation]; origName == originalPVCName {
   ```

3. This caused the function to never find the renamed PVC, so DataDownload couldn't be patched with the correct PVC name.

## Changes

### Code Changes
- **virtualmachinefilerestore_controller.go:2706-2713**: Changed from checking `Annotations` to checking `Labels` for `VMFROriginalPVCNameAnnotation`
- Updated comment from "Filter by annotation" to "Filter by label"

### Test Changes
- **virtualmachinefilerestore_controller_test.go**: 
  - Moved `VMFROriginalPVCNameAnnotation` from `Annotations` to `Labels` in all test PVCs (24 occurrences)
  - Updated test names to reflect "label" instead of "annotation"

## Testing

All unit tests pass:
```
=== RUN   TestFindRestoredPVCName
=== RUN   TestFindRestoredPVCName/finds_PVC_by_restore_label_and_original_name_label
=== RUN   TestFindRestoredPVCName/returns_error_when_no_PVCs_exist
=== RUN   TestFindRestoredPVCName/skips_PVCs_with_wrong_restore_label
=== RUN   TestFindRestoredPVCName/skips_PVCs_with_wrong_original_name_label_value
=== RUN   TestFindRestoredPVCName/skips_PVCs_with_nil_labels
=== RUN   TestFindRestoredPVCName/finds_correct_PVC_among_multiple_candidates
--- PASS: TestFindRestoredPVCName (0.00s)
```

## Impact

This fix enables the VMFR controller to correctly patch DataDownload resources with renamed PVC names, allowing Data Mover workflows to complete successfully when restoring multiple VM backups to the same namespace.