### PR TITLE
handle RestorePhaseFinalizingPartiallyFailed and status update race

### DIFF
--- a/internal/controller/virtualmachinefilerestore_controller.go
+++ b/internal/controller/virtualmachinefilerestore_controller.go
@@ -145,9 +145,10 @@ func (r *VirtualMachineFileRestoreReconciler) Reconcile(ctx context.Context, req
 		progressingCondition := meta.FindStatusCondition(vmfr.Status.Conditions, oadptypes.ConditionTypeProgressing)
 
 		// Check if we've completed validation and are in workflow execution phase
-		// Workflow reasons: ValidationCompleted (transition point), NamespaceReady, WaitingForRestores (monitoring), RestoresCompleted (credentials), CredentialsReady (file server creation), and future workflow steps
+		// Workflow reasons: DiscoveringPVCs (validation in progress), ValidationCompleted (transition point), NamespaceReady, WaitingForRestores (monitoring), RestoresCompleted (credentials), CredentialsReady (file server creation), and future workflow steps
 		isInWorkflowPhase := progressingCondition != nil &&
-			(progressingCondition.Reason == oadptypes.ReasonValidationCompleted ||
+			(progressingCondition.Reason == oadptypes.ReasonDiscoveringPVCs ||
+				progressingCondition.Reason == oadptypes.ReasonValidationCompleted ||
 				progressingCondition.Reason == oadptypes.ReasonNamespaceReady ||
 				progressingCondition.Reason == oadptypes.ReasonWaitingForRestores ||
 				progressingCondition.Reason == oadptypes.ReasonRestoresCompleted ||
@@ -686,6 +687,13 @@ func (r *VirtualMachineFileRestoreReconciler) executeFileRestoreWorkflow(ctx con
 
 	// Determine workflow step based on current Progressing reason
 	switch progressingCondition.Reason {
+	case oadptypes.ReasonDiscoveringPVCs:
+		// PVC discovery is in progress - this reconciliation was triggered by a status update
+		// The validation function already completed and updated status, so just requeue
+		// The next reconciliation will see ReasonValidationCompleted and proceed
+		logger.V(1).Info("PVC discovery already completed in previous reconciliation, waiting for status update")
+		return false, nil // Don't requeue - next reconciliation triggered by status update will proceed
+
 	case oadptypes.ReasonValidationCompleted:
 		// Step 1: Create or validate the restore namespace
 		// At this point, we know all PVCs have available backups (validated in validateAndDiscoverPVCs)
@@ -1080,9 +1088,14 @@ func (r *VirtualMachineFileRestoreReconciler) executeFileRestoreWorkflow(ctx con
 	case oadptypes.ReasonCredentialsReady:
 		logger.V(0).Info("Creating file server pod and service with validated credentials")
 
+		// IMPORTANT: Create patch baseline BEFORE modifying status
+		// This ensures FileServingInfo (populated by createFileServerResources) is included in the patch
+		patch := client.MergeFrom(vmfr.DeepCopy())
+
 		// Create file server pod and service
 		// PVCs are in Pending state - they will bind when the pod is created
 		// Credentials have been validated/copied/generated in previous step
+		// This also populates vmfr.Status.FileServingInfo in memory (without persisting)
 		err := r.createFileServerResources(ctx, logger, vmfr)
 		if err != nil {
 			failureMsg := fmt.Sprintf("Failed to create file server resources: %s", err.Error())
@@ -1093,6 +1106,9 @@ func (r *VirtualMachineFileRestoreReconciler) executeFileRestoreWorkflow(ctx con
 		logger.V(0).Info("File server resources created successfully")
 
 		// Update to final Completed phase with Available status
+		// These changes, along with FileServingInfo set above, will be included in the patch
+		vmfr.Status.Phase = oadpv1alpha1.VirtualMachineFileRestorePhaseCompleted
+
 		conditions := []metav1.Condition{
 			{
 				Type:               oadptypes.ConditionTypeProgressing,
@@ -1124,7 +1140,13 @@ func (r *VirtualMachineFileRestoreReconciler) executeFileRestoreWorkflow(ctx con
 			},
 		}
 
-		if err := r.patchVmfrStatusPhaseConditions(ctx, vmfr, oadpv1alpha1.VirtualMachineFileRestorePhaseCompleted, conditions, false, logger); err != nil {
+		for _, cond := range conditions {
+			meta.SetStatusCondition(&vmfr.Status.Conditions, cond)
+		}
+
+		// Apply single atomic patch with FileServingInfo + Phase + Conditions
+		if err := r.Status().Patch(ctx, vmfr, patch); err != nil {
+			logger.Error(err, "Failed to patch status with file server info and completed phase")
 			return false, err
 		}
 
@@ -1950,14 +1972,12 @@ func (r *VirtualMachineFileRestoreReconciler) updateFileServingInfo(
 		fileServingInfo.FileBrowser = fbInfo
 	}
 
-	// Update status with FileServingInfo
+	// Update FileServingInfo in vmfr.Status
+	// Note: Status is NOT persisted here - caller will do a single status update
+	// to avoid race conditions from multiple status updates
 	vmfr.Status.FileServingInfo = fileServingInfo
 
-	if err := r.Status().Update(ctx, vmfr); err != nil {
-		return fmt.Errorf("failed to update status with file serving info: %w", err)
-	}
-
-	logger.V(0).Info("Updated file serving info in status",
+	logger.V(0).Info("Prepared file serving info for status update",
 		"sshClusterAccess", func() string {
 			if fileServingInfo.SSH != nil {
 				return fileServingInfo.SSH.ClusterAccess
@@ -2501,8 +2521,9 @@ func (r *VirtualMachineFileRestoreReconciler) monitorVeleroRestores(
 
 		// Categorize by phase
 		switch restorePhase {
-		case veleroapi.RestorePhaseCompleted, veleroapi.RestorePhaseFinalizing:
-			// Treat Finalizing as completed since PVCs are already restored and available for mounting
+		case veleroapi.RestorePhaseCompleted, veleroapi.RestorePhaseFinalizing, veleroapi.RestorePhaseFinalizingPartiallyFailed:
+			// Treat Finalizing* phases as completed since PVCs are already restored and available for mounting
+			// FinalizingPartiallyFailed indicates some resources failed but PVCs may be ready - let PVC validation decide
 			completed++
 		case veleroapi.RestorePhaseFailed, veleroapi.RestorePhasePartiallyFailed, veleroapi.RestorePhaseFailedValidation:
 			failed++
@@ -2564,9 +2585,10 @@ func (r *VirtualMachineFileRestoreReconciler) monitorVeleroRestores(
 					}
 
 					// Always update phase if it changed (even if metadata was already set)
-					// Normalize Finalizing to Completed since from VMFR perspective they're equivalent
+					// Normalize Finalizing* phases to Completed since from VMFR perspective they're equivalent
+					// (PVCs are already created and available for mounting)
 					normalizedPhase := restorePhase
-					if restorePhase == veleroapi.RestorePhaseFinalizing {
+					if restorePhase == veleroapi.RestorePhaseFinalizing || restorePhase == veleroapi.RestorePhaseFinalizingPartiallyFailed {
 						normalizedPhase = veleroapi.RestorePhaseCompleted
 					}
 
@@ -2958,9 +2980,10 @@ func (r *VirtualMachineFileRestoreReconciler) createFileServerResources(
 		"serviceName", service.Name,
 		"namespace", restoreNamespace)
 
-	// Update FileServingInfo in status with access URLs and credentials
+	// Populate FileServingInfo in vmfr.Status with access URLs and credentials
+	// This prepares the data but doesn't persist it - the caller will do a single status update
 	if err := r.updateFileServingInfo(ctx, logger, vmfr, service); err != nil {
-		logger.Error(err, "Failed to update file serving info in status")
+		logger.Error(err, "Failed to prepare file serving info")
 		// Don't fail the entire operation, just log the error
 	}
 

--- a/internal/controller/virtualmachinefilerestore_controller_test.go
+++ b/internal/controller/virtualmachinefilerestore_controller_test.go
@@ -3614,6 +3614,64 @@ func TestMonitorVeleroRestores(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "finalizing partially failed restore treated as completed",
+			vmfr: &oadpv1alpha1.VirtualMachineFileRestore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmfr",
+					Namespace: "test-ns",
+					UID:       "test-uid",
+				},
+				Status: oadpv1alpha1.VirtualMachineFileRestoreStatus{
+					PVCRestores: []oadpv1alpha1.PVCRestoreInfo{
+						{
+							PVCInfo: oadptypes.PVCInfo{
+								PVCName:      "pvc-1",
+								PVCNamespace: "vm-ns",
+								PVCUID:       "pvc-uid-1",
+							},
+							Restores: []oadpv1alpha1.RestoreInfo{
+								{
+									VeleroBackupName:       "backup-1",
+									VeleroRestoreName:      "restore-1",
+									VeleroRestoreNamespace: "openshift-adp",
+									State:                  string(oadptypes.BackupDiscoveryStateAvailable),
+									Timestamp:              &time1,
+								},
+							},
+						},
+					},
+				},
+			},
+			existingRestores: []*velerov1api.Restore{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "restore-1",
+						Namespace: "openshift-adp",
+						Labels: map[string]string{
+							constant.VMFROriginUUIDLabel: "test-uid",
+						},
+						Annotations: map[string]string{
+							constant.BackupNameAnnotation: "backup-1",
+						},
+					},
+					Status: velerov1api.RestoreStatus{
+						Phase: velerov1api.RestorePhaseFinalizingPartiallyFailed,
+					},
+				},
+			},
+			expectedCompleted:  1,
+			expectedFailed:     0,
+			expectedInProgress: 0,
+			expectedUpdated:    true,
+			expectError:        false,
+			validateResults: func(t *testing.T, vmfr *oadpv1alpha1.VirtualMachineFileRestore) {
+				// FinalizingPartiallyFailed should be normalized to Completed
+				if vmfr.Status.PVCRestores[0].Restores[0].Phase != velerov1api.RestorePhaseCompleted {
+					t.Errorf("Expected phase Completed (normalized from FinalizingPartiallyFailed), got %s", vmfr.Status.PVCRestores[0].Restores[0].Phase)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
  ## Fix RestorePhaseFinalizingPartiallyFailed handling and status update issues

  ### Main Fix: Handle RestorePhaseFinalizingPartiallyFailed phase (#36)

  The openshift-velero-plugin restores PVCs successfully, but Velero Restore objects enter `RestorePhaseFinalizingPartiallyFailed` phase, causing the controller to hang indefinitely.

  **Changes:**
  - Added `RestorePhaseFinalizingPartiallyFailed` to completed phases in `monitorVeleroRestores()`
  - Normalized both `RestorePhaseFinalizing` and `RestorePhaseFinalizingPartiallyFailed` to `RestorePhaseCompleted` in status
  - Added test case for the new phase handling

  This aligns with the approach to prioritize PVC validation over Velero Restore status, allowing the workflow to proceed when PVCs are ready even if the Restore object shows partial failure. This will eventually be fixed in upstream, but we don't need to wait for upstream fix:
    **Upstream tracking:** vmware-tanzu/velero#9367, vmware-tanzu/velero#9368

  ### Fix #2: Race condition in FileServingInfo status updates

  **Issue:** Optimistic concurrency conflicts occurred during file server creation:

  ERROR Failed to update file serving info in status
  error: "Operation cannot be fulfilled... the object has been modified"

  **Root Cause:** Two sequential status updates without proper patch baseline timing:
  1. `updateFileServingInfo()` updates FileServingInfo
  2. `patchVmfrStatusPhaseConditions()` updates phase/conditions with stale object

  **Solution:**
  - Create patch baseline **before** calling `createFileServerResources()`
  - Changed `updateFileServingInfo()` to populate data in memory only (no persist)
  - Single atomic patch includes: FileServingInfo + Phase + Conditions

  ### Fix #3: Duplicate PVC discovery (pre-existing bug)

  **Issue:** The race condition fix exposed a pre-existing bug where PVC discovery ran twice when status updates triggered new reconciliations.

  **Root Cause:** `ReasonDiscoveringPVCs` was not included in the `isInWorkflowPhase` check, causing the controller to re-enter validation phase instead of continuing the workflow.

  **Solution:**
  - Added `ReasonDiscoveringPVCs` to workflow phase check
  - Added case handler to skip redundant discovery operations

  Fixes #36
