### PR TITLE
Fix backup timestamps to use completion time instead of creation time

### DIFF
--- a/api/v1alpha1/types/backup_discovery.go
+++ b/api/v1alpha1/types/backup_discovery.go
@@ -29,7 +29,9 @@ type VeleroBackupInfo struct {
 	// Namespace is the namespace of the backup resource
 	Namespace string `json:"namespace"`
 
-	// When the backup was created.
+	// When the backup was taken (from backup.status.completionTimestamp).
+	// For synced backups, this reflects when the backup actually completed, not when it was imported.
+	// +optional
 	CreatedAt *metav1.Time `json:"createdAt,omitempty"`
 
 	// PVCs contains the list of PVCs available in this backup

--- a/config/crd/bases/oadp.openshift.io_virtualmachinebackupsdiscoveries.yaml
+++ b/config/crd/bases/oadp.openshift.io_virtualmachinebackupsdiscoveries.yaml
@@ -99,7 +99,9 @@ spec:
                     about backup discovery progress
                   properties:
                     createdAt:
-                      description: When the backup was created.
+                      description: |-
+                        When the backup was taken (from backup.status.completionTimestamp).
+                        For synced backups, this reflects when the backup actually completed, not when it was imported.
                       format: date-time
                       type: string
                     lastUpdated:
@@ -274,7 +276,9 @@ spec:
                     that doesn't contain the VM
                   properties:
                     createdAt:
-                      description: When the backup was created.
+                      description: |-
+                        When the backup was taken (from backup.status.completionTimestamp).
+                        For synced backups, this reflects when the backup actually completed, not when it was imported.
                       format: date-time
                       type: string
                     name:
@@ -352,7 +356,9 @@ spec:
                     backup
                   properties:
                     createdAt:
-                      description: When the backup was created.
+                      description: |-
+                        When the backup was taken (from backup.status.completionTimestamp).
+                        For synced backups, this reflects when the backup actually completed, not when it was imported.
                       format: date-time
                       type: string
                     name:

--- a/internal/common/function/function.go
+++ b/internal/common/function/function.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/migtools/oadp-vm-file-restore/internal/common/constant"
+	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -513,4 +514,16 @@ func ValidateFileBrowserSecret(secret *corev1.Secret, logger logr.Logger) error 
 		"hasUsername", secret.Data["username"] != nil)
 
 	return nil
+}
+
+// GetBackupTimestamp returns the authoritative timestamp for when a Velero backup was taken.
+// It prefers CompletionTimestamp (when the backup actually finished) over CreationTimestamp
+// (when the backup object was created/imported).
+// This is critical for synced backups where CreationTimestamp reflects import time, not backup time.
+func GetBackupTimestamp(backup *veleroapi.Backup) *metav1.Time {
+	if backup.Status.CompletionTimestamp != nil {
+		return backup.Status.CompletionTimestamp
+	}
+	// Fallback to CreationTimestamp if CompletionTimestamp is not available
+	return &backup.CreationTimestamp
 }

--- a/internal/common/function/function_test.go
+++ b/internal/common/function/function_test.go
@@ -19,8 +19,10 @@ package function
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
+	veleroapi "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -861,6 +863,83 @@ func TestMin(t *testing.T) {
 			result := min(tt.a, tt.b)
 			if result != tt.expected {
 				t.Errorf("min(%d, %d) = %d, want %d", tt.a, tt.b, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetBackupTimestamp(t *testing.T) {
+	creationTime := metav1.NewTime(time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC))
+	completionTime := metav1.NewTime(time.Date(2025, 1, 15, 11, 30, 0, 0, time.UTC))
+
+	tests := []struct {
+		name      string
+		backup    veleroapi.Backup
+		wantTime  metav1.Time
+		wantIsNil bool
+	}{
+		{
+			name: "returns CompletionTimestamp when available",
+			backup: veleroapi.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-backup",
+					CreationTimestamp: creationTime,
+				},
+				Status: veleroapi.BackupStatus{
+					CompletionTimestamp: &completionTime,
+				},
+			},
+			wantTime:  completionTime,
+			wantIsNil: false,
+		},
+		{
+			name: "falls back to CreationTimestamp when CompletionTimestamp is nil",
+			backup: veleroapi.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "incomplete-backup",
+					CreationTimestamp: creationTime,
+				},
+				Status: veleroapi.BackupStatus{
+					CompletionTimestamp: nil,
+				},
+			},
+			wantTime:  creationTime,
+			wantIsNil: false,
+		},
+		{
+			name: "prefers CompletionTimestamp over CreationTimestamp for synced backups",
+			backup: veleroapi.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "synced-backup",
+					CreationTimestamp: metav1.NewTime(time.Date(2025, 10, 27, 17, 21, 0, 0, time.UTC)), // When imported
+				},
+				Status: veleroapi.BackupStatus{
+					CompletionTimestamp: &metav1.Time{Time: time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)}, // When actually taken
+				},
+			},
+			wantTime:  metav1.Time{Time: time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)},
+			wantIsNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetBackupTimestamp(&tt.backup)
+
+			if tt.wantIsNil {
+				if result != nil {
+					t.Errorf("Expected nil timestamp, got %v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Error("Expected non-nil timestamp, got nil")
+				return
+			}
+
+			if !result.Equal(&tt.wantTime) {
+				t.Errorf("GetBackupTimestamp() = %v, want %v", result, tt.wantTime)
 			}
 		})
 	}

--- a/internal/controller/fileserver_helpers.go
+++ b/internal/controller/fileserver_helpers.go
@@ -892,7 +892,7 @@ func buildFileServerRoute(config RouteConfig) (*routev1.Route, error) {
 }
 
 // extractPVCMountsFromVMFR extracts PVC mount information from VMFR status
-// Returns only successfully completed restores (one per PVC, choosing most recent)
+// Returns all successfully completed restores (including multiple backup versions of the same PVC)
 func extractPVCMountsFromVMFR(vmfr *oadpv1alpha1.VirtualMachineFileRestore) []PVCMountInfo {
 	var pvcMounts []PVCMountInfo
 
@@ -902,7 +902,8 @@ func extractPVCMountsFromVMFR(vmfr *oadpv1alpha1.VirtualMachineFileRestore) []PV
 			continue
 		}
 
-		// Find the most recent successfully completed restore for this PVC
+		// Mount ALL successfully completed restores for this PVC
+		// This allows users to access different backup versions of the same PVC
 		// Restores are already sorted by timestamp (newest first) in processDiscoveryResults
 		for _, restoreInfo := range pvcRestore.Restores {
 			// Include both Completed and Finalizing phases (PVCs are ready in both cases)
@@ -915,8 +916,7 @@ func extractPVCMountsFromVMFR(vmfr *oadpv1alpha1.VirtualMachineFileRestore) []PV
 					BackupTimestamp:   restoreInfo.Timestamp,
 					VeleroRestoreName: restoreInfo.VeleroRestoreName,
 				})
-				// Only mount the most recent successful restore per PVC
-				break
+				// Continue to next restore - mount all backup versions
 			}
 		}
 	}

--- a/internal/controller/fileserver_helpers_test.go
+++ b/internal/controller/fileserver_helpers_test.go
@@ -24,6 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	oadpv1alpha1 "github.com/migtools/oadp-vm-file-restore/api/v1alpha1"
+	oadptypes "github.com/migtools/oadp-vm-file-restore/api/v1alpha1/types"
 	"github.com/migtools/oadp-vm-file-restore/internal/common/constant"
 )
 
@@ -539,9 +541,303 @@ func TestGatherServicePorts(t *testing.T) {
 }
 
 func TestExtractPVCMountsFromVMFR(t *testing.T) {
-	// This test would require importing the API types
-	// Skipping for now as it's tested indirectly via integration tests
-	t.Skip("Requires full API types setup")
+	time1 := metav1.NewTime(time.Date(2025, 1, 27, 17, 21, 24, 0, time.UTC))
+	time2 := metav1.NewTime(time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC))
+
+	t.Run("single PVC with single backup version", func(t *testing.T) {
+		vmfr := &oadpv1alpha1.VirtualMachineFileRestore{
+			Status: oadpv1alpha1.VirtualMachineFileRestoreStatus{
+				PVCRestores: []oadpv1alpha1.PVCRestoreInfo{
+					{
+						PVCInfo: oadptypes.PVCInfo{
+							PVCName:      "test-vm-disk-1",
+							PVCNamespace: "vm-test-ns",
+							PVCUID:       "pvc-uid-1",
+						},
+						Restores: []oadpv1alpha1.RestoreInfo{
+							{
+								VeleroBackupName: "test-vm-backup-2025-01-27",
+								Phase:            "Completed",
+								State:            "available",
+								Timestamp:        &time1,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		result := extractPVCMountsFromVMFR(vmfr)
+
+		if len(result) != 1 {
+			t.Fatalf("Expected 1 PVC mount, got %d", len(result))
+		}
+
+		mount := result[0]
+		if mount.PVCName != "test-vm-disk-1" {
+			t.Errorf("Expected PVC name 'test-vm-disk-1', got '%s'", mount.PVCName)
+		}
+		if mount.BackupName != "test-vm-backup-2025-01-27" {
+			t.Errorf("Expected backup name 'test-vm-backup-2025-01-27', got '%s'", mount.BackupName)
+		}
+	})
+
+	t.Run("single PVC with multiple backup versions - should mount all", func(t *testing.T) {
+		vmfr := &oadpv1alpha1.VirtualMachineFileRestore{
+			Status: oadpv1alpha1.VirtualMachineFileRestoreStatus{
+				PVCRestores: []oadpv1alpha1.PVCRestoreInfo{
+					{
+						PVCInfo: oadptypes.PVCInfo{
+							PVCName:      "test-vm-disk-1",
+							PVCNamespace: "vm-test-ns",
+							PVCUID:       "pvc-uid-1",
+						},
+						Restores: []oadpv1alpha1.RestoreInfo{
+							{
+								VeleroBackupName:       "test-vm-backup-2025-01-27",
+								VeleroRestoreName:      "restore-1",
+								VeleroRestoreNamespace: "openshift-adp",
+								Phase:                  "Completed",
+								State:                  "available",
+								Timestamp:              &time1,
+							},
+							{
+								VeleroBackupName:       "test-vm-backup-2025-01-15",
+								VeleroRestoreName:      "restore-2",
+								VeleroRestoreNamespace: "openshift-adp",
+								Phase:                  "Completed",
+								State:                  "available",
+								Timestamp:              &time2,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		result := extractPVCMountsFromVMFR(vmfr)
+
+		// CRITICAL: Should return 2 mounts (one for each backup version), not just 1
+		if len(result) != 2 {
+			t.Fatalf("Expected 2 PVC mounts (one per backup version), got %d", len(result))
+		}
+
+		// Verify both backup versions are included
+		backupNames := make(map[string]bool)
+		for _, mount := range result {
+			if mount.PVCName != "test-vm-disk-1" {
+				t.Errorf("Expected PVC name 'test-vm-disk-1', got '%s'", mount.PVCName)
+			}
+			backupNames[mount.BackupName] = true
+		}
+
+		if !backupNames["test-vm-backup-2025-01-27"] {
+			t.Error("Expected backup 'test-vm-backup-2025-01-27' in mounts")
+		}
+		if !backupNames["test-vm-backup-2025-01-15"] {
+			t.Error("Expected backup 'test-vm-backup-2025-01-15' in mounts")
+		}
+	})
+
+	t.Run("skips non-completed restores", func(t *testing.T) {
+		vmfr := &oadpv1alpha1.VirtualMachineFileRestore{
+			Status: oadpv1alpha1.VirtualMachineFileRestoreStatus{
+				PVCRestores: []oadpv1alpha1.PVCRestoreInfo{
+					{
+						PVCInfo: oadptypes.PVCInfo{
+							PVCName:      "test-vm-disk-1",
+							PVCNamespace: "vm-test-ns",
+							PVCUID:       "pvc-uid-1",
+						},
+						Restores: []oadpv1alpha1.RestoreInfo{
+							{
+								VeleroBackupName: "test-vm-backup-completed",
+								Phase:            "Completed",
+								State:            "available",
+								Timestamp:        &time1,
+							},
+							{
+								VeleroBackupName: "test-vm-backup-failed",
+								Phase:            "Failed",
+								State:            "available",
+								Timestamp:        &time2,
+							},
+							{
+								VeleroBackupName: "test-vm-backup-in-progress",
+								Phase:            "InProgress",
+								State:            "available",
+								Timestamp:        &time2,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		result := extractPVCMountsFromVMFR(vmfr)
+
+		// Should only include the completed restore
+		if len(result) != 1 {
+			t.Fatalf("Expected 1 PVC mount (only completed), got %d", len(result))
+		}
+
+		if result[0].BackupName != "test-vm-backup-completed" {
+			t.Errorf("Expected backup 'test-vm-backup-completed', got '%s'", result[0].BackupName)
+		}
+	})
+
+	t.Run("includes Finalizing phase restores", func(t *testing.T) {
+		vmfr := &oadpv1alpha1.VirtualMachineFileRestore{
+			Status: oadpv1alpha1.VirtualMachineFileRestoreStatus{
+				PVCRestores: []oadpv1alpha1.PVCRestoreInfo{
+					{
+						PVCInfo: oadptypes.PVCInfo{
+							PVCName:      "test-vm-disk-1",
+							PVCNamespace: "vm-test-ns",
+							PVCUID:       "pvc-uid-1",
+						},
+						Restores: []oadpv1alpha1.RestoreInfo{
+							{
+								VeleroBackupName: "test-vm-backup-finalizing",
+								Phase:            "Finalizing",
+								State:            "available",
+								Timestamp:        &time1,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		result := extractPVCMountsFromVMFR(vmfr)
+
+		// Should include Finalizing phase
+		if len(result) != 1 {
+			t.Fatalf("Expected 1 PVC mount (Finalizing phase), got %d", len(result))
+		}
+
+		if result[0].BackupName != "test-vm-backup-finalizing" {
+			t.Errorf("Expected backup 'test-vm-backup-finalizing', got '%s'", result[0].BackupName)
+		}
+	})
+
+	t.Run("skips synthetic backup-level failure entries", func(t *testing.T) {
+		vmfr := &oadpv1alpha1.VirtualMachineFileRestore{
+			Status: oadpv1alpha1.VirtualMachineFileRestoreStatus{
+				PVCRestores: []oadpv1alpha1.PVCRestoreInfo{
+					{
+						PVCInfo: oadptypes.PVCInfo{
+							PVCName: constant.BackupLevelFailurePVCName, // Synthetic entry
+						},
+						Restores: []oadpv1alpha1.RestoreInfo{
+							{
+								VeleroBackupName: "failed-backup",
+								Phase:            "Completed",
+								State:            "available",
+							},
+						},
+					},
+					{
+						PVCInfo: oadptypes.PVCInfo{
+							PVCName:      "real-pvc",
+							PVCNamespace: "vm-test-ns",
+							PVCUID:       "pvc-uid-1",
+						},
+						Restores: []oadpv1alpha1.RestoreInfo{
+							{
+								VeleroBackupName: "real-backup",
+								Phase:            "Completed",
+								State:            "available",
+								Timestamp:        &time1,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		result := extractPVCMountsFromVMFR(vmfr)
+
+		// Should only include real PVC, not synthetic entry
+		if len(result) != 1 {
+			t.Fatalf("Expected 1 PVC mount (skipping synthetic), got %d", len(result))
+		}
+
+		if result[0].PVCName != "real-pvc" {
+			t.Errorf("Expected PVC name 'real-pvc', got '%s'", result[0].PVCName)
+		}
+	})
+
+	t.Run("multiple PVCs each with multiple backup versions", func(t *testing.T) {
+		vmfr := &oadpv1alpha1.VirtualMachineFileRestore{
+			Status: oadpv1alpha1.VirtualMachineFileRestoreStatus{
+				PVCRestores: []oadpv1alpha1.PVCRestoreInfo{
+					{
+						PVCInfo: oadptypes.PVCInfo{
+							PVCName:      "disk-1",
+							PVCNamespace: "vm-test-ns",
+							PVCUID:       "uid-1",
+						},
+						Restores: []oadpv1alpha1.RestoreInfo{
+							{
+								VeleroBackupName: "backup-new",
+								Phase:            "Completed",
+								State:            "available",
+								Timestamp:        &time1,
+							},
+							{
+								VeleroBackupName: "backup-old",
+								Phase:            "Completed",
+								State:            "available",
+								Timestamp:        &time2,
+							},
+						},
+					},
+					{
+						PVCInfo: oadptypes.PVCInfo{
+							PVCName:      "disk-2",
+							PVCNamespace: "vm-test-ns",
+							PVCUID:       "uid-2",
+						},
+						Restores: []oadpv1alpha1.RestoreInfo{
+							{
+								VeleroBackupName: "backup-new",
+								Phase:            "Completed",
+								State:            "available",
+								Timestamp:        &time1,
+							},
+							{
+								VeleroBackupName: "backup-old",
+								Phase:            "Completed",
+								State:            "available",
+								Timestamp:        &time2,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		result := extractPVCMountsFromVMFR(vmfr)
+
+		// Should return 4 mounts: 2 PVCs × 2 backup versions each
+		if len(result) != 4 {
+			t.Fatalf("Expected 4 PVC mounts (2 PVCs × 2 versions), got %d", len(result))
+		}
+
+		// Count mounts per PVC
+		pvcCounts := make(map[string]int)
+		for _, mount := range result {
+			pvcCounts[mount.PVCName]++
+		}
+
+		if pvcCounts["disk-1"] != 2 {
+			t.Errorf("Expected 2 mounts for disk-1, got %d", pvcCounts["disk-1"])
+		}
+		if pvcCounts["disk-2"] != 2 {
+			t.Errorf("Expected 2 mounts for disk-2, got %d", pvcCounts["disk-2"])
+		}
+	})
 }
 
 func TestBuildBackupPVCMapJSON(t *testing.T) {

--- a/internal/controller/virtualmachinebackupsdiscovery_controller.go
+++ b/internal/controller/virtualmachinebackupsdiscovery_controller.go
@@ -38,6 +38,7 @@ import (
 	oadpv1alpha1 "github.com/migtools/oadp-vm-file-restore/api/v1alpha1"
 	"github.com/migtools/oadp-vm-file-restore/api/v1alpha1/types"
 	"github.com/migtools/oadp-vm-file-restore/internal/common/constant"
+	"github.com/migtools/oadp-vm-file-restore/internal/common/function"
 	"github.com/migtools/oadp-vm-file-restore/internal/velerohelpers"
 )
 
@@ -340,7 +341,7 @@ func (r *VirtualMachineBackupsDiscoveryReconciler) initializeDiscovery(ctx conte
 			VeleroBackupInfo: types.VeleroBackupInfo{
 				Name:      backup.Name,
 				Namespace: r.OADPNamespace,
-				CreatedAt: &backup.CreationTimestamp,
+				CreatedAt: function.GetBackupTimestamp(&backup),
 			},
 			Status:      types.BackupDiscoveryStatusNew,
 			LastUpdated: &metav1.Time{Time: time.Now()},

--- a/internal/controller/virtualmachinefilerestore_controller.go
+++ b/internal/controller/virtualmachinefilerestore_controller.go
@@ -1370,7 +1370,9 @@ func (r *VirtualMachineFileRestoreReconciler) getBackupMetadata(
 		VeleroBackupInfo: oadptypes.VeleroBackupInfo{
 			Name:      backupInfo.Name,
 			Namespace: backupInfo.Namespace,
-			CreatedAt: &veleroBackup.CreationTimestamp,
+			// Use completionTimestamp (when backup actually finished) instead of creationTimestamp
+			// This is critical for synced backups where creationTimestamp reflects import time
+			CreatedAt: function.GetBackupTimestamp(veleroBackup),
 		},
 		Status:      oadptypes.BackupDiscoveryStatusInProgress,
 		Message:     "Extracting PVC information",
@@ -1533,7 +1535,6 @@ func (r *VirtualMachineFileRestoreReconciler) buildFailedProgress(
 		VeleroBackupInfo: oadptypes.VeleroBackupInfo{
 			Name:      backupInfo.Name,
 			Namespace: backupInfo.Namespace,
-			CreatedAt: backupInfo.CreatedAt,
 			PVCs:      []oadptypes.PVCInfo{}, // Empty list for failed discoveries
 		},
 		Status:      oadptypes.BackupDiscoveryStatusFailed,
@@ -1605,9 +1606,10 @@ func (r *VirtualMachineFileRestoreReconciler) processDiscoveryResults(
 					{
 						VeleroBackupName:      backupProgress.Name,
 						VeleroBackupNamespace: backupProgress.Namespace,
-						Timestamp:             backupProgress.CreatedAt,
-						State:                 state,
-						FailureReason:         backupProgress.Message,
+						// Use backup completion timestamp (when backup finished) not creation timestamp
+						Timestamp:     backupProgress.CreatedAt,
+						State:         state,
+						FailureReason: backupProgress.Message,
 					},
 				},
 			}
@@ -1636,8 +1638,9 @@ func (r *VirtualMachineFileRestoreReconciler) processDiscoveryResults(
 			restoreInfo := oadpv1alpha1.RestoreInfo{
 				VeleroBackupName:      backupProgress.Name,
 				VeleroBackupNamespace: backupProgress.Namespace,
-				Timestamp:             backupProgress.CreatedAt,
-				State:                 state,
+				// Use backup completion timestamp (when backup finished) not creation timestamp
+				Timestamp: backupProgress.CreatedAt,
+				State:     state,
 				// VeleroRestore* fields will be populated later when Velero Restore objects are created
 			}
 

--- a/internal/controller/virtualmachinefilerestore_controller_test.go
+++ b/internal/controller/virtualmachinefilerestore_controller_test.go
@@ -859,9 +859,8 @@ func TestBuildFailedProgress(t *testing.T) {
 		if result.VeleroBackupInfo.Namespace != testOADPNamespace {
 			t.Errorf("Expected namespace '%s', got '%s'", testOADPNamespace, result.VeleroBackupInfo.Namespace)
 		}
-		if result.VeleroBackupInfo.CreatedAt != &createdAt {
-			t.Error("CreatedAt timestamp not preserved")
-		}
+		// Note: buildFailedProgress doesn't preserve CreatedAt since it's used for early failures
+		// where backup metadata hasn't been retrieved yet
 
 		// Verify PVCs is empty list
 		if result.VeleroBackupInfo.PVCs == nil {
@@ -2727,6 +2726,9 @@ func TestGetBackupMetadata(t *testing.T) {
 						Name:              "test-backup",
 						Namespace:         "openshift-adp",
 						CreationTimestamp: createdTime,
+					},
+					Status: velerov1api.BackupStatus{
+						CompletionTimestamp: &createdTime,
 					},
 				},
 			},


### PR DESCRIPTION
Fix backup timestamps to use completion time instead of creation time      

Fixes Issue #38 

For synced backups, CreationTimestamp shows when the backup was imported
to the cluster, not when it was actually taken. This caused VMBD to show
incorrect backup dates.

This caused mountpoints to be improper in the restored data.
Ensure this fix is merged *after* #37, because it's based on that commit.

Changes:
  - Add GetBackupTimestamp() common function that prefers CompletionTimestamp
  - Update VMBD and VMFR controllers to use completion timestamp

### VMBD before change
```yaml
  validBackups:
    - createdAt: '2025-10-27T17:21:24Z'
      name: test-vm-backup-20250115
      namespace: openshift-adp
    - createdAt: '2025-10-27T17:21:23Z'
      name: test-vm-backup-2025-10-27
      namespace: openshift-adp
```

### VMBD after change
```yaml
    validBackups:
    - createdAt: '2025-10-23T23:25:48Z'
      name: test-vm-backup-20250115
      namespace: openshift-adp
    - createdAt: '2025-10-27T12:30:06Z'
      name: test-vm-backup-2025-10-27
      namespace: openshift-adp
```

### METADATA.json before change
```json
{
  "mounted_at": "2025-10-28T11:09:41.489425",
  "mount_structure": "date-organized",
  "path_format": "/restores/<date>/<backup>/<pvc>/",
  "backups": [
    {
      "backup_name": "test-vm-backup-2025-10-27",
      "pvcs": [
        {
          "pvc_name": "test-vm-disk-1",
          "source_path": "/dev/pvc-075f7553-2df7-4149-a895-3f9f05f8ffef",
          "mount_path": "/restores/2025-10-27/test-vm-backup-2025-10-27/test-vm-disk-1",
          "backup_date": "2025-10-27",
          "mount_status": "success"
        }
      ]
    },
    {
      "backup_name": "test-vm-backup-20250115",
      "pvcs": [
        {
          "pvc_name": "test-vm-disk-1",
          "source_path": "/dev/pvc-fcb97a95-6668-4714-8a01-5eefcef76f49",
          "mount_path": "/restores/2025-10-27/test-vm-backup-20250115/test-vm-disk-1",
          "backup_date": "2025-10-27",
          "mount_status": "success"
        }
      ]
    }
  ],
  "statistics": {
    "total_backups": 2,
    "total_pvcs": 2,
    "successful_mounts": 2,
    "failed_mounts": 0
  }
}
```

### METADATA.json after fix

```json
{
  "mounted_at": "2025-10-28T11:53:31.078070",
  "mount_structure": "date-organized",
  "path_format": "/restores/<date>/<backup>/<pvc>/",
  "backups": [
    {
      "backup_name": "test-vm-backup-2025-10-27",
      "pvcs": [
        {
          "pvc_name": "test-vm-disk-1",
          "source_path": "/dev/pvc-1c1e3767-f482-4000-9716-acc17ce695a9",
          "mount_path": "/restores/2025-10-27/test-vm-backup-2025-10-27/test-vm-disk-1",
          "backup_date": "2025-10-27",
          "mount_status": "success"
        }
      ]
    },
    {
      "backup_name": "test-vm-backup-20250115",
      "pvcs": [
        {
          "pvc_name": "test-vm-disk-1",
          "source_path": "/dev/pvc-2bb38324-84f6-4ee0-84c8-23e6e7cd860b",
          "mount_path": "/restores/2025-10-24/test-vm-backup-20250115/test-vm-disk-1",
          "backup_date": "2025-10-24",
          "mount_status": "success"
        }
      ]
    }
  ],
  "statistics": {
    "total_backups": 2,
    "total_pvcs": 2,
    "successful_mounts": 2,
    "failed_mounts": 0
  }
}
```