### PR TITLE
Prevent reconcile from the non WATCH_NAMESPACE

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,6 +38,8 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -219,6 +221,23 @@ func main() {
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "8f8d9561.openshift.io",
 		Logger:                 zap.New(zap.UseFlagOptions(&opts)),
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				// Only watch VMBD and VMFR resources in the OADP namespace
+				&oadpv1alpha1.VirtualMachineBackupsDiscovery{}: {
+					Namespaces: map[string]cache.Config{
+						oadpNamespace: {},
+					},
+				},
+				&oadpv1alpha1.VirtualMachineFileRestore{}: {
+					Namespaces: map[string]cache.Config{
+						oadpNamespace: {},
+					},
+				},
+				// Other resources (Services, Routes, Pods, Velero Restores, etc.) watch all namespaces
+				// to support dynamically created temporary restore namespaces
+			},
+		},
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/internal/controller/virtualmachinebackupsdiscovery_controller.go
+++ b/internal/controller/virtualmachinebackupsdiscovery_controller.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -39,6 +40,7 @@ import (
 	"github.com/migtools/oadp-vm-file-restore/api/v1alpha1/types"
 	"github.com/migtools/oadp-vm-file-restore/internal/common/constant"
 	"github.com/migtools/oadp-vm-file-restore/internal/common/function"
+	"github.com/migtools/oadp-vm-file-restore/internal/predicate"
 	"github.com/migtools/oadp-vm-file-restore/internal/velerohelpers"
 )
 
@@ -937,7 +939,8 @@ func (r *VirtualMachineBackupsDiscoveryReconciler) updateStatusWithRetry(ctx con
 // SetupWithManager sets up the controller with the Manager.
 func (r *VirtualMachineBackupsDiscoveryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&oadpv1alpha1.VirtualMachineBackupsDiscovery{}).
+		For(&oadpv1alpha1.VirtualMachineBackupsDiscovery{},
+			builder.WithPredicates(predicate.NamespacePredicate{Namespace: r.OADPNamespace})).
 		Watches(&velerov1api.Backup{}, handler.EnqueueRequestsFromMapFunc(r.mapBackupToVMBD)).
 		Named("virtualmachinebackupsdiscovery").
 		Complete(r)

--- a/internal/controller/virtualmachinefilerestore_controller.go
+++ b/internal/controller/virtualmachinefilerestore_controller.go
@@ -1745,8 +1745,10 @@ func (r *VirtualMachineFileRestoreReconciler) getDiscoveryResource(ctx context.C
 // SetupWithManager sets up the controller with the Manager.
 func (r *VirtualMachineFileRestoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
-		For(&oadpv1alpha1.VirtualMachineFileRestore{}).
-		Watches(&oadpv1alpha1.VirtualMachineBackupsDiscovery{}, handler.EnqueueRequestsFromMapFunc(r.mapVMBDToVMFR)).
+		For(&oadpv1alpha1.VirtualMachineFileRestore{},
+			builder.WithPredicates(predicate.NamespacePredicate{Namespace: r.OADPNamespace})).
+		Watches(&oadpv1alpha1.VirtualMachineBackupsDiscovery{}, handler.EnqueueRequestsFromMapFunc(r.mapVMBDToVMFR),
+			builder.WithPredicates(predicate.NamespacePredicate{Namespace: r.OADPNamespace})).
 		Watches(&veleroapi.Restore{}, handler.EnqueueRequestsFromMapFunc(r.mapVeleroRestoreToVMFR),
 			builder.WithPredicates(predicate.VeleroRestorePredicate{OADPNamespace: r.OADPNamespace})).
 		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(r.mapServiceToVMFR),
@@ -1818,6 +1820,11 @@ func (r *VirtualMachineFileRestoreReconciler) mapVeleroRestoreToVMFR(ctx context
 		return nil
 	}
 
+	// Only enqueue reconcile requests for VMFRs in the OADP namespace
+	if vmfrNamespace != r.OADPNamespace {
+		return nil
+	}
+
 	// Return a reconcile request for the VMFR that owns this Velero Restore
 	return []ctrl.Request{
 		{
@@ -1849,6 +1856,11 @@ func (r *VirtualMachineFileRestoreReconciler) mapServiceToVMFR(ctx context.Conte
 		return nil
 	}
 
+	// Only enqueue reconcile requests for VMFRs in the OADP namespace
+	if vmfrNamespace != r.OADPNamespace {
+		return nil
+	}
+
 	// Return a reconcile request for the VMFR that owns this Service
 	return []ctrl.Request{
 		{
@@ -1872,6 +1884,11 @@ func (r *VirtualMachineFileRestoreReconciler) mapRouteToVMFR(ctx context.Context
 	vmfrName, nameExists := obj.GetAnnotations()[constant.VMFROriginNameAnnotation]
 	vmfrNamespace, nsExists := obj.GetAnnotations()[constant.VMFROriginNamespaceAnnotation]
 	if !nameExists || !nsExists {
+		return nil
+	}
+
+	// Only enqueue reconcile requests for VMFRs in the OADP namespace
+	if vmfrNamespace != r.OADPNamespace {
 		return nil
 	}
 

--- a/internal/controller/virtualmachinefilerestore_controller_test.go
+++ b/internal/controller/virtualmachinefilerestore_controller_test.go
@@ -6169,13 +6169,13 @@ func TestMapVeleroRestoreToVMFR(t *testing.T) {
 					},
 					Annotations: map[string]string{
 						constant.VMFROriginNameAnnotation:      "my-vmfr",
-						constant.VMFROriginNamespaceAnnotation: "default",
+						constant.VMFROriginNamespaceAnnotation: testOADPNamespace,
 					},
 				},
 			},
 			expectedRequest: true,
 			expectedName:    "my-vmfr",
-			expectedNS:      "default",
+			expectedNS:      testOADPNamespace,
 		},
 		{
 			name: "restore without VMFR label",
@@ -6237,7 +6237,9 @@ func TestMapVeleroRestoreToVMFR(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &VirtualMachineFileRestoreReconciler{}
+			r := &VirtualMachineFileRestoreReconciler{
+				OADPNamespace: testOADPNamespace,
+			}
 
 			requests := r.mapVeleroRestoreToVMFR(context.TODO(), tt.restore)
 
@@ -6280,13 +6282,13 @@ func TestMapServiceToVMFR(t *testing.T) {
 					},
 					Annotations: map[string]string{
 						constant.VMFROriginNameAnnotation:      "my-vmfr",
-						constant.VMFROriginNamespaceAnnotation: "default",
+						constant.VMFROriginNamespaceAnnotation: testOADPNamespace,
 					},
 				},
 			},
 			expectedRequest: true,
 			expectedName:    "my-vmfr",
-			expectedNS:      "default",
+			expectedNS:      testOADPNamespace,
 		},
 		{
 			name: "service without VMFR label",
@@ -6332,7 +6334,9 @@ func TestMapServiceToVMFR(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &VirtualMachineFileRestoreReconciler{}
+			r := &VirtualMachineFileRestoreReconciler{
+				OADPNamespace: testOADPNamespace,
+			}
 
 			requests := r.mapServiceToVMFR(context.TODO(), tt.service)
 
@@ -6375,13 +6379,13 @@ func TestMapRouteToVMFR(t *testing.T) {
 					},
 					Annotations: map[string]string{
 						constant.VMFROriginNameAnnotation:      "my-vmfr",
-						constant.VMFROriginNamespaceAnnotation: "default",
+						constant.VMFROriginNamespaceAnnotation: testOADPNamespace,
 					},
 				},
 			},
 			expectedRequest: true,
 			expectedName:    "my-vmfr",
-			expectedNS:      "default",
+			expectedNS:      testOADPNamespace,
 		},
 		{
 			name: "route without VMFR label",
@@ -6417,7 +6421,9 @@ func TestMapRouteToVMFR(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &VirtualMachineFileRestoreReconciler{}
+			r := &VirtualMachineFileRestoreReconciler{
+				OADPNamespace: testOADPNamespace,
+			}
 
 			requests := r.mapRouteToVMFR(context.TODO(), tt.route)
 

--- a/internal/predicate/namespace_predicate.go
+++ b/internal/predicate/namespace_predicate.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package predicate implements event filtering predicates for various Kubernetes resources
+// used by the OADP VM file restore controller.
+package predicate
+
+import (
+	"context"
+
+	"github.com/migtools/oadp-vm-file-restore/internal/common/function"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+// NamespacePredicate filters events to only accept objects from a specific namespace
+type NamespacePredicate struct {
+	Namespace string
+}
+
+// Create event filter only accepts objects from the specified namespace
+func (p NamespacePredicate) Create(evt event.CreateEvent) bool {
+	logger := function.GetLogger(context.Background(), evt.Object, "NamespacePredicate")
+
+	if evt.Object.GetNamespace() == p.Namespace {
+		logger.V(1).Info("Accepted Create event from namespace", "namespace", p.Namespace)
+		return true
+	}
+
+	logger.V(1).Info("Rejected Create event - wrong namespace",
+		"objectNamespace", evt.Object.GetNamespace(),
+		"expectedNamespace", p.Namespace)
+	return false
+}
+
+// Update event filter only accepts objects from the specified namespace
+func (p NamespacePredicate) Update(evt event.TypedUpdateEvent[client.Object]) bool {
+	logger := function.GetLogger(context.Background(), evt.ObjectNew, "NamespacePredicate")
+
+	if evt.ObjectNew.GetNamespace() == p.Namespace {
+		logger.V(1).Info("Accepted Update event from namespace", "namespace", p.Namespace)
+		return true
+	}
+
+	logger.V(1).Info("Rejected Update event - wrong namespace",
+		"objectNamespace", evt.ObjectNew.GetNamespace(),
+		"expectedNamespace", p.Namespace)
+	return false
+}
+
+// Delete event filter only accepts objects from the specified namespace
+func (p NamespacePredicate) Delete(evt event.DeleteEvent) bool {
+	logger := function.GetLogger(context.Background(), evt.Object, "NamespacePredicate")
+
+	if evt.Object.GetNamespace() == p.Namespace {
+		logger.V(1).Info("Accepted Delete event from namespace", "namespace", p.Namespace)
+		return true
+	}
+
+	logger.V(1).Info("Rejected Delete event - wrong namespace",
+		"objectNamespace", evt.Object.GetNamespace(),
+		"expectedNamespace", p.Namespace)
+	return false
+}
+
+// Generic determines whether to process generic events from the specified namespace
+func (p NamespacePredicate) Generic(evt event.GenericEvent) bool {
+	logger := function.GetLogger(context.Background(), evt.Object, "NamespacePredicate")
+
+	if evt.Object.GetNamespace() == p.Namespace {
+		logger.V(1).Info("Accepted Generic event from namespace", "namespace", p.Namespace)
+		return true
+	}
+
+	logger.V(1).Info("Rejected Generic event - wrong namespace",
+		"objectNamespace", evt.Object.GetNamespace(),
+		"expectedNamespace", p.Namespace)
+	return false
+}

--- a/internal/predicate/namespace_predicate_test.go
+++ b/internal/predicate/namespace_predicate_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicate
+
+import (
+	"testing"
+
+	oadpv1alpha1 "github.com/migtools/oadp-vm-file-restore/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestNamespacePredicate_Create(t *testing.T) {
+	tests := []struct {
+		name           string
+		namespace      string
+		vmbd           *oadpv1alpha1.VirtualMachineBackupsDiscovery
+		expectedAccept bool
+		description    string
+	}{
+		{
+			name:      "create in correct namespace",
+			namespace: "openshift-adp",
+			vmbd: &oadpv1alpha1.VirtualMachineBackupsDiscovery{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmbd",
+					Namespace: "openshift-adp",
+				},
+			},
+			expectedAccept: true,
+			description:    "should accept events from the specified namespace",
+		},
+		{
+			name:      "create in wrong namespace",
+			namespace: "openshift-adp",
+			vmbd: &oadpv1alpha1.VirtualMachineBackupsDiscovery{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmbd",
+					Namespace: "other-namespace",
+				},
+			},
+			expectedAccept: false,
+			description:    "should reject events from other namespaces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predicate := NamespacePredicate{Namespace: tt.namespace}
+
+			evt := event.CreateEvent{
+				Object: tt.vmbd,
+			}
+
+			result := predicate.Create(evt)
+			if result != tt.expectedAccept {
+				t.Errorf("%s: expected %v, got %v", tt.description, tt.expectedAccept, result)
+			}
+		})
+	}
+}
+
+func TestNamespacePredicate_Update(t *testing.T) {
+	tests := []struct {
+		name           string
+		namespace      string
+		oldVMBD        *oadpv1alpha1.VirtualMachineBackupsDiscovery
+		newVMBD        *oadpv1alpha1.VirtualMachineBackupsDiscovery
+		expectedAccept bool
+		description    string
+	}{
+		{
+			name:      "update in correct namespace",
+			namespace: "openshift-adp",
+			oldVMBD: &oadpv1alpha1.VirtualMachineBackupsDiscovery{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmbd",
+					Namespace: "openshift-adp",
+				},
+			},
+			newVMBD: &oadpv1alpha1.VirtualMachineBackupsDiscovery{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmbd",
+					Namespace: "openshift-adp",
+				},
+			},
+			expectedAccept: true,
+			description:    "should accept update events from the specified namespace",
+		},
+		{
+			name:      "update in wrong namespace",
+			namespace: "openshift-adp",
+			oldVMBD: &oadpv1alpha1.VirtualMachineBackupsDiscovery{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmbd",
+					Namespace: "other-namespace",
+				},
+			},
+			newVMBD: &oadpv1alpha1.VirtualMachineBackupsDiscovery{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmbd",
+					Namespace: "other-namespace",
+				},
+			},
+			expectedAccept: false,
+			description:    "should reject update events from other namespaces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predicate := NamespacePredicate{Namespace: tt.namespace}
+
+			evt := event.TypedUpdateEvent[client.Object]{
+				ObjectOld: tt.oldVMBD,
+				ObjectNew: tt.newVMBD,
+			}
+
+			result := predicate.Update(evt)
+			if result != tt.expectedAccept {
+				t.Errorf("%s: expected %v, got %v", tt.description, tt.expectedAccept, result)
+			}
+		})
+	}
+}
+
+func TestNamespacePredicate_Delete(t *testing.T) {
+	tests := []struct {
+		name           string
+		namespace      string
+		vmbd           *oadpv1alpha1.VirtualMachineBackupsDiscovery
+		expectedAccept bool
+		description    string
+	}{
+		{
+			name:      "delete in correct namespace",
+			namespace: "openshift-adp",
+			vmbd: &oadpv1alpha1.VirtualMachineBackupsDiscovery{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmbd",
+					Namespace: "openshift-adp",
+				},
+			},
+			expectedAccept: true,
+			description:    "should accept delete events from the specified namespace",
+		},
+		{
+			name:      "delete in wrong namespace",
+			namespace: "openshift-adp",
+			vmbd: &oadpv1alpha1.VirtualMachineBackupsDiscovery{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmbd",
+					Namespace: "other-namespace",
+				},
+			},
+			expectedAccept: false,
+			description:    "should reject delete events from other namespaces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predicate := NamespacePredicate{Namespace: tt.namespace}
+
+			evt := event.DeleteEvent{
+				Object: tt.vmbd,
+			}
+
+			result := predicate.Delete(evt)
+			if result != tt.expectedAccept {
+				t.Errorf("%s: expected %v, got %v", tt.description, tt.expectedAccept, result)
+			}
+		})
+	}
+}
+
+func TestNamespacePredicate_Generic(t *testing.T) {
+	tests := []struct {
+		name           string
+		namespace      string
+		vmbd           *oadpv1alpha1.VirtualMachineBackupsDiscovery
+		expectedAccept bool
+		description    string
+	}{
+		{
+			name:      "generic in correct namespace",
+			namespace: "openshift-adp",
+			vmbd: &oadpv1alpha1.VirtualMachineBackupsDiscovery{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmbd",
+					Namespace: "openshift-adp",
+				},
+			},
+			expectedAccept: true,
+			description:    "should accept generic events from the specified namespace",
+		},
+		{
+			name:      "generic in wrong namespace",
+			namespace: "openshift-adp",
+			vmbd: &oadpv1alpha1.VirtualMachineBackupsDiscovery{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmbd",
+					Namespace: "other-namespace",
+				},
+			},
+			expectedAccept: false,
+			description:    "should reject generic events from other namespaces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predicate := NamespacePredicate{Namespace: tt.namespace}
+
+			evt := event.GenericEvent{
+				Object: tt.vmbd,
+			}
+
+			result := predicate.Generic(evt)
+			if result != tt.expectedAccept {
+				t.Errorf("%s: expected %v, got %v", tt.description, tt.expectedAccept, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #41 

Controllers were processing resources from all namespaces instead of respecting the WATCH_NAMESPACE environment variable. This caused reconciliation of resources outside the OADP namespace and "unknown namespace for the cache" errors.