### PR TITLE
Cleanup logic rework to allow storage to be freed

### DIFF
--- a/containers/oadp-vmfr-access/Dockerfile
+++ b/containers/oadp-vmfr-access/Dockerfile
@@ -58,6 +58,8 @@ LABEL name="oadp-vmfr-access" \
 # See README.md "Installed Tools - Why Each Tool Is Needed" for detailed rationale
 #
 RUN dnf install -y \
+                --setopt=install_weak_deps=False \
+                --setopt=tsflags=nodocs \
     # =========================================================================
     # Category 1: VM Disk Image Tools - CRITICAL for reading VM disk images
     # =========================================================================
@@ -141,6 +143,12 @@ RUN dnf install -y \
     #   - Why: ALL VM disks have partition tables
     #   - Coverage: 100% of VMs have partitions
     parted \
+    #
+    # kpartx: Partition mapper for devices
+    #   - Why: Maps partitions inside raw disk images (used by guestmount/libguestfs)
+    #   - Use case: Required for mounting disk images with multiple partitions
+    #   - Impact: Without this, guestmount may fail on partitioned disks
+    kpartx \
     #
     # gdisk: GPT partition table support (UEFI VMs)
     #   - Why: GPT (GUID Partition Table) is standard for modern UEFI VMs

--- a/containers/oadp-vmfr-access/scripts/detect-and-mount.sh
+++ b/containers/oadp-vmfr-access/scripts/detect-and-mount.sh
@@ -75,6 +75,53 @@ error() {
     echo "[$(date +'%Y-%m-%d %H:%M:%S')] ERROR: $*" >&2
 }
 
+# cleanup_mounts - Cleanup function called on script termination
+# This is the secondary mechanism (trap-based) that works with the primary
+# PreStop hook in the controller. See issue #44.
+# Unmounts all FUSE filesystems to prevent pods/PVCs from getting stuck in Terminating state
+cleanup_mounts() {
+    # Disable strict error handling for cleanup - we want to try everything
+    # even if individual operations fail
+    set +e
+    set +u
+    set +o pipefail
+
+    log "[Trap] Received termination signal, cleaning up FUSE mounts..."
+
+    local mounted_count=0
+    local unmounted_count=0
+
+    # Find all FUSE mount points under /restores/
+    # Structure: /restores/<date>/<backup>/<pvc>/
+    if [ -d "$FS_MOUNT_DIR" ]; then
+        # Use shopt to handle failed glob patterns gracefully
+        shopt -s nullglob 2>/dev/null || true
+        for mount_point in "$FS_MOUNT_DIR"/*/*/*; do
+            # Check if it's a directory
+            if [ -d "$mount_point" ]; then
+                # Check if it's actually a mount point
+                if mountpoint -q "$mount_point" 2>/dev/null; then
+                    mounted_count=$((mounted_count + 1))
+                    log "[Trap] Unmounting: $mount_point"
+                    # Use existing unmount_disk function
+                    unmount_disk "$mount_point" || true
+                    unmounted_count=$((unmounted_count + 1))
+                fi
+            fi
+        done
+        shopt -u nullglob 2>/dev/null || true
+    fi
+
+    log "[Trap] Cleanup complete: unmounted $unmounted_count of $mounted_count FUSE mounts"
+    log "[Trap] Exiting gracefully"
+}
+
+# Set up trap to handle termination signals
+# SIGTERM: Kubernetes sends this when deleting the pod
+# SIGINT: User presses Ctrl+C
+# EXIT: Script exits for any reason
+trap cleanup_mounts SIGTERM SIGINT EXIT
+
 # detect_disk_format - Identify the disk image format
 #
 # Uses qemu-img to detect the format of a disk image file.
@@ -574,10 +621,15 @@ main() {
     log "Keeping container alive to maintain FUSE mounts..."
     log "Container will run indefinitely (sleep infinity)"
     log ""
+    log "Trap handler installed for graceful cleanup on termination"
+    log ""
 
     # Sleep forever to keep container running
+    # IMPORTANT: Do NOT use 'exec sleep' - we need the bash process to stay alive
+    # to handle trap signals (SIGTERM/SIGINT) for graceful FUSE unmounting
+    # The '& wait $!' pattern allows trap handlers to execute before termination
     # Future: This will be replaced with SSH/HTTP server (Issues #8, #9)
-    exec sleep infinity
+    sleep infinity & wait $!
 }
 
 # Execute main function with all script arguments

--- a/internal/common/constant/constant.go
+++ b/internal/common/constant/constant.go
@@ -74,8 +74,8 @@ const (
 // Common string constants
 const (
 	EmptyString     = ""
-	TrueString      = "True"
-	FalseString     = "False"
+	TrueString      = "true"  // lowercase to match Kubernetes conventions and external plugin expectations
+	FalseString     = "false" // lowercase to match Kubernetes conventions
 	NameDelimiter   = "-"
 	NamespaceString = "Namespace"
 	NameString      = "name"

--- a/internal/common/constant/constant_test.go
+++ b/internal/common/constant/constant_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constant
+
+import "testing"
+
+// TestBooleanStringConstants verifies that boolean string constants follow Kubernetes conventions.
+// CRITICAL: These MUST be lowercase to ensure:
+// 1. Compatibility with kubevirt-velero-plugin (expects lowercase "true")
+// 2. Kubernetes label/annotation conventions (lowercase boolean values)
+// 3. Proper namespace cleanup (temp namespace label matching)
+//
+// DO NOT change these to capital case ("True"/"False") as it will break:
+// - PVC creation (kubevirt-velero-plugin won't recognize annotations)
+// - Namespace cleanup (label matching will fail)
+// - External integrations expecting standard Kubernetes conventions
+//
+// See issue #44 and related fixes for context.
+func TestBooleanStringConstants(t *testing.T) {
+	tests := []struct {
+		name          string
+		constantValue string
+		expectedValue string
+		reason        string
+	}{
+		{
+			name:          "TrueString must be lowercase",
+			constantValue: TrueString,
+			expectedValue: "true",
+			reason:        "Kubernetes conventions and kubevirt-velero-plugin expect lowercase 'true'",
+		},
+		{
+			name:          "FalseString must be lowercase",
+			constantValue: FalseString,
+			expectedValue: "false",
+			reason:        "Kubernetes conventions expect lowercase 'false'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.constantValue != tt.expectedValue {
+				t.Errorf("CRITICAL: %s has incorrect value.\n"+
+					"  Got:      %q\n"+
+					"  Expected: %q\n"+
+					"  Reason:   %s\n"+
+					"  Impact:   Changing this will break kubevirt-velero-plugin integration and namespace cleanup.\n"+
+					"  See:      Issue #44 and related PR for details.",
+					tt.name, tt.constantValue, tt.expectedValue, tt.reason)
+			}
+		})
+	}
+}
+
+// TestTrueStringNotCapitalized ensures TrueString is not capitalized.
+// This test will fail if someone accidentally changes "true" to "True".
+func TestTrueStringNotCapitalized(t *testing.T) {
+	if TrueString == "True" {
+		t.Error("CRITICAL: TrueString must be lowercase 'true', not 'True'. " +
+			"Capital case breaks kubevirt-velero-plugin and namespace cleanup. " +
+			"See issue #44.")
+	}
+
+	if TrueString == "TRUE" {
+		t.Error("CRITICAL: TrueString must be lowercase 'true', not 'TRUE'. " +
+			"All-caps breaks Kubernetes conventions.")
+	}
+}
+
+// TestFalseStringNotCapitalized ensures FalseString is not capitalized.
+// This test will fail if someone accidentally changes "false" to "False".
+func TestFalseStringNotCapitalized(t *testing.T) {
+	if FalseString == "False" {
+		t.Error("CRITICAL: FalseString must be lowercase 'false', not 'False'. " +
+			"Capital case breaks Kubernetes conventions.")
+	}
+
+	if FalseString == "FALSE" {
+		t.Error("CRITICAL: FalseString must be lowercase 'false', not 'FALSE'. " +
+			"All-caps breaks Kubernetes conventions.")
+	}
+}
+
+// TestBooleanStringConstantsUsageInLabels verifies that TrueString works correctly
+// in label comparisons (the original bug that caused namespace cleanup to fail).
+func TestBooleanStringConstantsUsageInLabels(t *testing.T) {
+	// Simulate how the constants are used in production code
+	labels := map[string]string{
+		VMFRTempNamespaceLabel: TrueString,
+		ManagedByLabel:         ManagedByLabelValue,
+	}
+
+	// Verify the label value is lowercase (critical for namespace cleanup)
+	if labels[VMFRTempNamespaceLabel] != "true" {
+		t.Errorf("VMFRTempNamespaceLabel should be set to lowercase 'true', got %q. "+
+			"This will break namespace cleanup logic.", labels[VMFRTempNamespaceLabel])
+	}
+
+	// Verify comparison works (this is how cleanup code checks for temp namespaces)
+	isTempNamespace := labels[VMFRTempNamespaceLabel] == TrueString
+	if !isTempNamespace {
+		t.Error("Temp namespace detection failed. Label comparison doesn't work correctly.")
+	}
+}
+
+// TestBooleanStringConstantsUsageInAnnotations verifies that TrueString works correctly
+// in Velero Restore annotations (critical for kubevirt-velero-plugin).
+func TestBooleanStringConstantsUsageInAnnotations(t *testing.T) {
+	// Simulate how the constants are used in Velero Restore annotations
+	annotations := map[string]string{
+		"oadp.openshift.io/vmfr-restore": TrueString,
+	}
+
+	// Verify the annotation value is lowercase (critical for kubevirt-velero-plugin)
+	if annotations["oadp.openshift.io/vmfr-restore"] != "true" {
+		t.Errorf("vmfr-restore annotation should be lowercase 'true', got %q. "+
+			"This will break kubevirt-velero-plugin PVC uniquification.",
+			annotations["oadp.openshift.io/vmfr-restore"])
+	}
+}

--- a/internal/controller/container_scripts.go
+++ b/internal/controller/container_scripts.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package controller contains initialization scripts for sidecar containers
+// Package controller contains initialization and lifecycle scripts for VMFR containers
 package controller
 
 // fileBrowserInitScript is the initialization script for the FileBrowser sidecar container.
@@ -148,4 +148,76 @@ else
     --root "${FB_ROOT}" \
     --database "${FB_DATABASE}"
 fi
+`
+
+// vmFileServerPreStopScript is the cleanup script for the VM file server main container.
+// This script runs as a PreStop lifecycle hook, which executes BEFORE the container receives SIGTERM.
+// It ensures all FUSE filesystems (created by guestmount) are properly unmounted before pod termination.
+//
+// The script:
+// - Discovers all FUSE mount points under /restores/*/*/*
+// - Unmounts each filesystem using guestunmount (preferred) or fusermount -u (fallback)
+// - Uses fail-safe operations (no 'set -e', all commands have '|| true')
+// - Always exits with success to prevent blocking pod termination
+//
+// This works in conjunction with the trap handler in detect-and-mount.sh (belt-and-suspenders approach).
+// See issue #44: https://github.com/migtools/oadp-vm-file-restore/issues/44
+const vmFileServerPreStopScript = `# Do NOT use 'set -e' - we want to continue even if some commands fail
+echo "[PreStop] Starting cleanup of FUSE mounts..."
+
+# Function to safely unmount a FUSE mount point
+unmount_fuse() {
+    local mount_point="$1"
+    echo "[PreStop] Unmounting: $mount_point"
+
+    # Try guestunmount first (preferred for libguestfs FUSE mounts)
+    if command -v guestunmount >/dev/null 2>&1; then
+        if guestunmount "$mount_point" 2>/dev/null; then
+            echo "[PreStop] ✓ Successfully unmounted with guestunmount: $mount_point"
+            return 0
+        fi
+    fi
+
+    # Fallback to fusermount -u for generic FUSE unmounts
+    if fusermount -u "$mount_point" 2>/dev/null; then
+        echo "[PreStop] ✓ Successfully unmounted with fusermount: $mount_point"
+        return 0
+    fi
+
+    # If both fail, log but don't fail the hook (mount may already be gone)
+    echo "[PreStop] ⚠ Could not unmount: $mount_point (may not be mounted)"
+    return 0
+}
+
+# Find all FUSE mount points under /restores/
+# Structure: /restores/<date>/<backup>/<pvc>/
+# We look for depth 3 directories which are the actual mount points
+
+mounted_count=0
+unmounted_count=0
+
+# Find mount points at depth 3: /restores/YYYY-MM-DD/backup-name/pvc-name/
+if [ -d /restores ]; then
+    # Use shopt to handle failed glob patterns gracefully
+    shopt -s nullglob
+    for mount_point in /restores/*/*/*; do
+        # Check if it's a directory
+        if [ -d "$mount_point" ]; then
+            # Check if it's actually a mount point using mountpoint command
+            if mountpoint -q "$mount_point" 2>/dev/null; then
+                mounted_count=$((mounted_count + 1))
+                unmount_fuse "$mount_point" || true
+                unmounted_count=$((unmounted_count + 1))
+            fi
+        fi
+    done
+    shopt -u nullglob
+fi
+
+echo "[PreStop] Cleanup complete: unmounted $unmounted_count of $mounted_count FUSE mounts"
+
+# Give the system a moment to fully process the unmounts
+sleep 1 || true
+
+exit 0
 `

--- a/internal/controller/fileserver_helpers.go
+++ b/internal/controller/fileserver_helpers.go
@@ -617,6 +617,19 @@ func buildVMFileServerMainContainer(pvcMounts []PVCMountInfo) corev1.Container {
 			},
 		},
 
+		// Lifecycle hooks
+		// PreStop: Kubernetes-native cleanup hook (primary mechanism)
+		// This is guaranteed to run BEFORE the container receives SIGTERM
+		// Works in conjunction with trap handler in detect-and-mount.sh (secondary mechanism)
+		// See issue #44: https://github.com/migtools/oadp-vm-file-restore/issues/44
+		Lifecycle: &corev1.Lifecycle{
+			PreStop: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"/bin/bash", "-c", vmFileServerPreStopScript},
+				},
+			},
+		},
+
 		// Container-level security context
 		// CRITICAL: Privileged mode required for /dev/kvm access with SELinux
 		SecurityContext: &corev1.SecurityContext{

--- a/internal/controller/virtualmachinefilerestore_controller.go
+++ b/internal/controller/virtualmachinefilerestore_controller.go
@@ -2106,7 +2106,7 @@ func (r *VirtualMachineFileRestoreReconciler) ensureRestoreNamespace(
 			Name: namespaceName,
 			Labels: map[string]string{
 				constant.VMFROriginUUIDLabel:    string(vmfr.UID),
-				constant.VMFRTempNamespaceLabel: "true",
+				constant.VMFRTempNamespaceLabel: constant.TrueString,
 				constant.ManagedByLabel:         constant.ManagedByLabelValue,
 			},
 			OwnerReferences: []metav1.OwnerReference{
@@ -2392,7 +2392,7 @@ func (r *VirtualMachineFileRestoreReconciler) createVeleroRestores(
 					constant.VirtualMachineNameAnnotation:      vmbd.Spec.VirtualMachineName,
 					constant.VirtualMachineNamespaceAnnotation: vmbd.Spec.VirtualMachineNamespace,
 					constant.BackupNameAnnotation:              backupName,
-					"oadp.openshift.io/vmfr-restore":           "true",
+					"oadp.openshift.io/vmfr-restore":           constant.TrueString,
 				},
 			},
 			Spec: veleroapi.RestoreSpec{
@@ -3883,6 +3883,11 @@ func (r *VirtualMachineFileRestoreReconciler) handleResourceCleanup(
 			return false, err
 		}
 
+		// Delete file server routes created by this controller (OpenShift only)
+		if err := r.deleteFileServerRoutes(ctx, logger, vmfr, restoreNamespace); err != nil {
+			return false, err
+		}
+
 		// Delete PVCs restored by this VMFR's Velero Restore objects
 		if err := r.deleteRestoredPVCs(ctx, logger, vmfr, restoreNamespace); err != nil {
 			return false, err
@@ -3901,6 +3906,12 @@ func (r *VirtualMachineFileRestoreReconciler) handleResourceCleanup(
 	patch := client.MergeFrom(vmfr.DeepCopy())
 	controllerutil.RemoveFinalizer(vmfr, constant.VMFileRestoreFinalizer)
 	if err := r.Patch(ctx, vmfr, patch); err != nil {
+		if apierrors.IsNotFound(err) {
+			// VMFR was already deleted (possibly force-deleted during cleanup)
+			// This is fine - cleanup is complete
+			logger.V(0).Info("VMFR already deleted, cleanup complete")
+			return false, nil
+		}
 		logger.Error(err, "Failed to remove VMFileRestoreFinalizer")
 		return false, fmt.Errorf("failed to remove VMFileRestoreFinalizer: %w", err)
 	}
@@ -4127,5 +4138,63 @@ func (r *VirtualMachineFileRestoreReconciler) deleteFileServerServices(
 	}
 
 	logger.V(0).Info("Deleted file server services", "count", deletedCount, "namespace", namespace)
+	return nil
+}
+
+// deleteFileServerRoutes removes file server routes created by this controller (OpenShift only).
+// Routes are identified by the VMFROriginUUIDLabel matching this VMFR's UID.
+// This function gracefully handles non-OpenShift clusters by checking if the Route CRD exists.
+func (r *VirtualMachineFileRestoreReconciler) deleteFileServerRoutes(
+	ctx context.Context,
+	logger logr.Logger,
+	vmfr *oadpv1alpha1.VirtualMachineFileRestore,
+	namespace string,
+) error {
+	logger.V(0).Info("Deleting file server routes", "namespace", namespace)
+
+	// Check if Route CRD exists (OpenShift only)
+	// On non-OpenShift clusters, skip this step
+	routeList := &routev1.RouteList{}
+	testErr := r.List(ctx, routeList, client.Limit(1))
+	if testErr != nil {
+		// Route CRD doesn't exist - skip route deletion (not an OpenShift cluster)
+		logger.V(1).Info("Route CRD not available, skipping route deletion (expected on non-OpenShift clusters)")
+		return nil
+	}
+
+	// List routes created by this VMFR
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			constant.VMFROriginUUIDLabel: string(vmfr.UID),
+		},
+	}
+
+	if err := r.List(ctx, routeList, listOpts...); err != nil {
+		logger.Error(err, "Failed to list file server routes")
+		return fmt.Errorf("failed to list file server routes: %w", err)
+	}
+
+	logger.V(0).Info("Found file server routes to delete", "count", len(routeList.Items))
+
+	deletedCount := 0
+	for i := range routeList.Items {
+		route := &routeList.Items[i]
+		logger.V(1).Info("Deleting file server route",
+			"routeName", route.Name,
+			"namespace", route.Namespace)
+
+		if err := r.Delete(ctx, route); err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.V(1).Info("Route already deleted", "routeName", route.Name)
+				continue
+			}
+			logger.Error(err, "Failed to delete route", "routeName", route.Name)
+			return fmt.Errorf("failed to delete route %s: %w", route.Name, err)
+		}
+		deletedCount++
+	}
+
+	logger.V(0).Info("Deleted file server routes", "count", deletedCount, "namespace", namespace)
 	return nil
 }

--- a/internal/controller/virtualmachinefilerestore_controller_test.go
+++ b/internal/controller/virtualmachinefilerestore_controller_test.go
@@ -505,7 +505,7 @@ var _ = Describe("VirtualMachineFileRestore Controller", func() {
 
 			// Verify labels
 			Expect(ns.Labels).To(HaveKeyWithValue(constant.VMFROriginUUIDLabel, "12345678-1234-5678-9012-123456789012"))
-			Expect(ns.Labels).To(HaveKeyWithValue(constant.VMFRTempNamespaceLabel, "true"))
+			Expect(ns.Labels).To(HaveKeyWithValue(constant.VMFRTempNamespaceLabel, constant.TrueString))
 			Expect(ns.Labels).To(HaveKeyWithValue(constant.ManagedByLabel, constant.ManagedByLabelValue))
 
 			// Verify owner references
@@ -2135,6 +2135,393 @@ func TestHandleVeleroRestoreCleanup(t *testing.T) {
 			if tt.expectDeletedCount != expectedToDelete {
 				t.Errorf("Test setup error: expectDeletedCount=%d but calculated %d restores should be deleted",
 					tt.expectDeletedCount, expectedToDelete)
+			}
+		})
+	}
+}
+
+func TestHandleResourceCleanup(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = oadpv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = routev1.AddToScheme(scheme)
+	ctx := context.Background()
+
+	tests := []struct {
+		name                   string
+		vmfr                   *oadpv1alpha1.VirtualMachineFileRestore
+		existingNamespace      *corev1.Namespace
+		existingPods           []*corev1.Pod
+		existingServices       []*corev1.Service
+		existingRoutes         []*routev1.Route
+		expectRequeue          bool
+		expectError            bool
+		expectFinalizerRemoved bool
+		expectNamespaceDeleted bool
+		expectPodsDeleted      int
+		expectServicesDeleted  int
+		expectRoutesDeleted    int
+	}{
+		{
+			name: "finalizer not present returns false",
+			vmfr: &oadpv1alpha1.VirtualMachineFileRestore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-vmfr",
+					Namespace:  "openshift-adp",
+					UID:        "test-uid",
+					Finalizers: []string{}, // No finalizer
+				},
+				Status: oadpv1alpha1.VirtualMachineFileRestoreStatus{
+					CreatedNamespace: "test-ns",
+				},
+			},
+			existingNamespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ns",
+				},
+			},
+			expectRequeue:          false,
+			expectError:            false,
+			expectFinalizerRemoved: false,
+			expectNamespaceDeleted: false,
+		},
+		{
+			name: "no namespace in status removes finalizer",
+			vmfr: &oadpv1alpha1.VirtualMachineFileRestore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmfr",
+					Namespace: "openshift-adp",
+					UID:       "test-uid",
+					Finalizers: []string{
+						constant.VMFileRestoreFinalizer,
+					},
+				},
+				Status: oadpv1alpha1.VirtualMachineFileRestoreStatus{
+					CreatedNamespace: "", // No namespace
+				},
+			},
+			expectRequeue:          false,
+			expectError:            false,
+			expectFinalizerRemoved: true,
+		},
+		{
+			name: "deletes temporary namespace created by controller",
+			vmfr: &oadpv1alpha1.VirtualMachineFileRestore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmfr",
+					Namespace: "openshift-adp",
+					UID:       "test-uid",
+					Finalizers: []string{
+						constant.VMFileRestoreFinalizer,
+					},
+				},
+				Status: oadpv1alpha1.VirtualMachineFileRestoreStatus{
+					CreatedNamespace: "vm-test-ns-abcd",
+				},
+			},
+			existingNamespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "vm-test-ns-abcd",
+					Labels: map[string]string{
+						constant.VMFRTempNamespaceLabel: constant.TrueString,
+						constant.VMFROriginUUIDLabel:    "test-uid",
+					},
+				},
+			},
+			expectRequeue:          false,
+			expectError:            false,
+			expectFinalizerRemoved: true,
+			expectNamespaceDeleted: true,
+		},
+		{
+			name: "cleans up resources in user-provided namespace including routes",
+			vmfr: &oadpv1alpha1.VirtualMachineFileRestore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmfr",
+					Namespace: "openshift-adp",
+					UID:       "test-uid",
+					Finalizers: []string{
+						constant.VMFileRestoreFinalizer,
+					},
+				},
+				Status: oadpv1alpha1.VirtualMachineFileRestoreStatus{
+					CreatedNamespace: "user-ns",
+				},
+			},
+			existingNamespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "user-ns",
+					// No VMFRTempNamespaceLabel - user-provided namespace
+				},
+			},
+			existingPods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "user-ns",
+						Labels: map[string]string{
+							constant.VMFROriginUUIDLabel: "test-uid",
+							"app":                        "vmfr-file-server",
+						},
+					},
+				},
+			},
+			existingServices: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-service",
+						Namespace: "user-ns",
+						Labels: map[string]string{
+							constant.VMFROriginUUIDLabel: "test-uid",
+							"app":                        "vmfr-file-server",
+						},
+					},
+				},
+			},
+			existingRoutes: []*routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-route",
+						Namespace: "user-ns",
+						Labels: map[string]string{
+							constant.VMFROriginUUIDLabel: "test-uid",
+						},
+					},
+				},
+			},
+			expectRequeue:          false,
+			expectError:            false,
+			expectFinalizerRemoved: true,
+			expectNamespaceDeleted: false, // User-provided namespace should not be deleted
+			expectPodsDeleted:      1,
+			expectServicesDeleted:  1,
+			expectRoutesDeleted:    1,
+		},
+		{
+			name: "cleans up multiple routes in user namespace",
+			vmfr: &oadpv1alpha1.VirtualMachineFileRestore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmfr",
+					Namespace: "openshift-adp",
+					UID:       "test-uid",
+					Finalizers: []string{
+						constant.VMFileRestoreFinalizer,
+					},
+				},
+				Status: oadpv1alpha1.VirtualMachineFileRestoreStatus{
+					CreatedNamespace: "user-ns",
+				},
+			},
+			existingNamespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "user-ns",
+				},
+			},
+			existingRoutes: []*routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "filebrowser-route",
+						Namespace: "user-ns",
+						Labels: map[string]string{
+							constant.VMFROriginUUIDLabel: "test-uid",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "another-route",
+						Namespace: "user-ns",
+						Labels: map[string]string{
+							constant.VMFROriginUUIDLabel: "test-uid",
+						},
+					},
+				},
+			},
+			expectRequeue:          false,
+			expectError:            false,
+			expectFinalizerRemoved: true,
+			expectRoutesDeleted:    2,
+		},
+		{
+			name: "skips routes without matching label",
+			vmfr: &oadpv1alpha1.VirtualMachineFileRestore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmfr",
+					Namespace: "openshift-adp",
+					UID:       "test-uid",
+					Finalizers: []string{
+						constant.VMFileRestoreFinalizer,
+					},
+				},
+				Status: oadpv1alpha1.VirtualMachineFileRestoreStatus{
+					CreatedNamespace: "user-ns",
+				},
+			},
+			existingNamespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "user-ns",
+				},
+			},
+			existingRoutes: []*routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vmfr-route",
+						Namespace: "user-ns",
+						Labels: map[string]string{
+							constant.VMFROriginUUIDLabel: "test-uid",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "other-route",
+						Namespace: "user-ns",
+						Labels: map[string]string{
+							constant.VMFROriginUUIDLabel: "different-uid",
+						},
+					},
+				},
+			},
+			expectRequeue:          false,
+			expectError:            false,
+			expectFinalizerRemoved: true,
+			expectRoutesDeleted:    1, // Only one route with matching UID
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objects := []client.Object{tt.vmfr}
+			if tt.existingNamespace != nil {
+				objects = append(objects, tt.existingNamespace)
+			}
+			for _, pod := range tt.existingPods {
+				objects = append(objects, pod)
+			}
+			for _, svc := range tt.existingServices {
+				objects = append(objects, svc)
+			}
+			for _, route := range tt.existingRoutes {
+				objects = append(objects, route)
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+
+			reconciler := &VirtualMachineFileRestoreReconciler{
+				Client:        fakeClient,
+				Scheme:        scheme,
+				OADPNamespace: "openshift-adp",
+			}
+
+			requeue, err := reconciler.handleResourceCleanup(ctx, zap.New(), tt.vmfr)
+
+			// Validate error expectations
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error, got %v", err)
+				}
+			}
+
+			// Validate requeue expectation
+			if requeue != tt.expectRequeue {
+				t.Errorf("Expected requeue=%v, got %v", tt.expectRequeue, requeue)
+			}
+
+			// Get updated VMFR to check finalizer
+			updated := &oadpv1alpha1.VirtualMachineFileRestore{}
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: tt.vmfr.Name, Namespace: tt.vmfr.Namespace}, updated)
+			if err != nil {
+				t.Fatalf("Failed to get updated VMFR: %v", err)
+			}
+
+			// Validate finalizer removal
+			hasFinalizer := controllerutil.ContainsFinalizer(updated, constant.VMFileRestoreFinalizer)
+			if tt.expectFinalizerRemoved && hasFinalizer {
+				t.Error("Expected finalizer to be removed, but it's still present")
+			}
+			if !tt.expectFinalizerRemoved && !hasFinalizer && len(tt.vmfr.Finalizers) > 0 {
+				t.Error("Expected finalizer to remain, but it was removed")
+			}
+
+			// Check namespace deletion if expected
+			if tt.existingNamespace != nil {
+				ns := &corev1.Namespace{}
+				err = fakeClient.Get(ctx, types.NamespacedName{Name: tt.existingNamespace.Name}, ns)
+				if tt.expectNamespaceDeleted {
+					if err == nil {
+						// Check if deletion timestamp is set (namespace is being deleted)
+						if ns.DeletionTimestamp == nil {
+							t.Error("Expected namespace to be marked for deletion, but DeletionTimestamp is nil")
+						}
+					}
+				} else {
+					if err != nil {
+						t.Errorf("Expected namespace to exist, got error: %v", err)
+					}
+				}
+			}
+
+			// Validate pod deletion count
+			if tt.expectPodsDeleted > 0 {
+				remainingPods := &corev1.PodList{}
+				listOpts := []client.ListOption{
+					client.InNamespace(tt.vmfr.Status.CreatedNamespace),
+					client.MatchingLabels{
+						constant.VMFROriginUUIDLabel: string(tt.vmfr.UID),
+						"app":                        "vmfr-file-server",
+					},
+				}
+				err = fakeClient.List(ctx, remainingPods, listOpts...)
+				if err != nil {
+					t.Fatalf("Failed to list remaining pods: %v", err)
+				}
+				if len(remainingPods.Items) != 0 {
+					t.Errorf("Expected 0 remaining pods, found %d", len(remainingPods.Items))
+				}
+			}
+
+			// Validate service deletion count
+			if tt.expectServicesDeleted > 0 {
+				remainingServices := &corev1.ServiceList{}
+				listOpts := []client.ListOption{
+					client.InNamespace(tt.vmfr.Status.CreatedNamespace),
+					client.MatchingLabels{
+						constant.VMFROriginUUIDLabel: string(tt.vmfr.UID),
+						"app":                        "vmfr-file-server",
+					},
+				}
+				err = fakeClient.List(ctx, remainingServices, listOpts...)
+				if err != nil {
+					t.Fatalf("Failed to list remaining services: %v", err)
+				}
+				if len(remainingServices.Items) != 0 {
+					t.Errorf("Expected 0 remaining services, found %d", len(remainingServices.Items))
+				}
+			}
+
+			// Validate route deletion count (KEY TEST FOR ISSUE FIX)
+			if tt.expectRoutesDeleted > 0 {
+				remainingRoutes := &routev1.RouteList{}
+				listOpts := []client.ListOption{
+					client.InNamespace(tt.vmfr.Status.CreatedNamespace),
+					client.MatchingLabels{
+						constant.VMFROriginUUIDLabel: string(tt.vmfr.UID),
+					},
+				}
+				err = fakeClient.List(ctx, remainingRoutes, listOpts...)
+				if err != nil {
+					t.Fatalf("Failed to list remaining routes: %v", err)
+				}
+				if len(remainingRoutes.Items) != 0 {
+					t.Errorf("Expected 0 remaining routes after cleanup, found %d. This indicates routes are not being cleaned up properly (issue #44 related bug).", len(remainingRoutes.Items))
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Note: additional small fix to the Docerfile making it ~300 MB smaller.

Fix Issue #44: Pods Stuck in Terminating State

##  Problem

Pods with FUSE-mounted VM disk images remained in Terminating state indefinitely because guestmount filesystems weren't being unmounted before pod deletion. This prevented storage from being freed and caused namespace cleanup to hang.

##  Solution

Implemented dual cleanup mechanisms to ensure FUSE mounts are always unmounted:

  1. PreStop Lifecycle Hook

  File: internal/controller/fileserver_helpers.go

  Added Kubernetes-native preStop hook that runs before SIGTERM is sent to the container:
  - Unmounts all FUSE filesystems in /restores/*/*/*
  - Uses fail-safe operations (no set -e, all commands have || true)
  - Falls back from guestunmount to fusermount -u

  2. Signal Trap Handler

  File: containers/oadp-vmfr-access/scripts/detect-and-mount.sh

  Added trap handler to catch termination signals:
  - Traps SIGTERM, SIGINT, and EXIT
  - Changed exec sleep infinity to sleep infinity & wait $! to allow trap execution
  - Calls cleanup_mounts() function to unmount all FUSE filesystems

  3. Route Cleanup Bug Fix

  File: internal/controller/virtualmachinefilerestore_controller.go

  Routes were being orphaned after VMFR deletion:
  - Created deleteFileServerRoutes() function
  - Integrated into cleanup flow in handleResourceCleanup()
  - Gracefully handles non-OpenShift clusters

  4. Namespace Label Case Mismatch

  Files: internal/common/constant/constant.go, internal/controller/virtualmachinefilerestore_controller.go

  Temp namespaces weren't being deleted due to string case mismatch:
  - Changed TrueString = "True" to TrueString = "true" (lowercase)
  - Changed FalseString = "False" to FalseString = "false" (lowercase)
  - Fixed hardcoded "true" literals to use constant.TrueString
  - Added 5 tests to prevent future developers from accidentally changing "true" and "false" constants.


##  Why Both PreStop and Trap?

Ensures cleanup happens even if one mechanism fails:
  - PreStop hook: Kubernetes-native, runs first
  - Trap handler: Shell-level fallback, catches signals the hook might miss

## Test results
Manual tests performed with monitoring of ceph:

```shell
# Before vmfr creation
$ ceph -s
  cluster:
    id:     dad61f4c-8761-4396-a04b-db2a04375e7c
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum a,b,c (age 9m)
    mgr: b(active, since 16m), standbys: a
    mds: 1/1 daemons up, 1 hot standby
    osd: 3 osds: 3 up (since 9m), 3 in (since 3w)
 
  data:
    volumes: 1/1 healthy
    pools:   8 pools, 260 pgs
    objects: 2.48k objects, 6.5 GiB
    usage:   19 GiB used, 191 GiB / 210 GiB avail
    pgs:     260 active+clean
 
  io:
    client:   3.2 KiB/s rd, 511 B/s wr, 4 op/s rd, 75 op/s wr


# After vmfr creation
$ ceph -s
  cluster:
    id:     dad61f4c-8761-4396-a04b-db2a04375e7c
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum a,b,c (age 19m)
    mgr: b(active, since 26m), standbys: a
    mds: 1/1 daemons up, 1 hot standby
    osd: 3 osds: 3 up (since 19m), 3 in (since 3w)
 
  data:
    volumes: 1/1 healthy
    pools:   8 pools, 260 pgs
    objects: 4.03k objects, 12 GiB
    usage:   37 GiB used, 173 GiB / 210 GiB avail
    pgs:     260 active+clean
 
  io:
    client:   267 KiB/s rd, 15 MiB/s wr, 314 op/s rd, 92 op/s wr

# After vmfr deletion
$ ceph -s
  cluster:
    id:     dad61f4c-8761-4396-a04b-db2a04375e7c
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum a,b,c (age 49m)
    mgr: b(active, since 57m), standbys: a
    mds: 1/1 daemons up, 1 hot standby
    osd: 3 osds: 3 up (since 49m), 3 in (since 3w)
 
  data:
    volumes: 1/1 healthy
    pools:   8 pools, 260 pgs
    objects: 2.50k objects, 6.5 GiB
    usage:   19 GiB used, 191 GiB / 210 GiB avail
    pgs:     260 active+clean
 
  io:
    client:   852 B/s rd, 1 op/s rd, 0 op/s wr
```