### PR TITLE
Fix: OADP-7344: Reject backups with incomplete async operations

### DIFF
--- a/internal/controller/virtualmachinebackupsdiscovery_controller.go
+++ b/internal/controller/virtualmachinebackupsdiscovery_controller.go
@@ -283,6 +283,13 @@ func (r *VirtualMachineBackupsDiscoveryReconciler) initializeDiscovery(ctx conte
 			continue
 		}
 
+		// Skip backups with incomplete async operations (e.g., data mover upload not finished)
+		// This prevents attempting restores from backups where the DataUpload completed
+		// after the backup was marked as Completed, leaving BackupItemOperationsCompleted unset.
+		if velerohelpers.BackupAsyncOperationsIncomplete(&backup) {
+			continue
+		}
+
 		// Check if backup should be included based on time range and/or explicit list
 		includeByTime := !backup.CreationTimestamp.Time.Before(startTime) && !backup.CreationTimestamp.Time.After(endTime)
 		includeByExplicitList := false
@@ -351,66 +358,8 @@ func (r *VirtualMachineBackupsDiscoveryReconciler) initializeDiscovery(ctx conte
 	}
 
 	// Handle missing and filtered backups when explicit list is provided
-	var invalidBackups []types.InvalidBackupInfo
-	var missingBackupsCount int
-	var filteredOutBackups []types.BackupDiscoveryProgress
-
+	invalidBackups, missingBackupsCount, filteredOutBackups := r.classifyRequestedBackups(vmbd, backupList)
 	if len(vmbd.Spec.RequestedBackups) > 0 {
-		// Check which requested backups exist and classify them
-		requestedBackupsStatus := make(map[string]string) // name -> status: "missing", "filtered", "candidate"
-		for _, requestedName := range vmbd.Spec.RequestedBackups {
-			requestedBackupsStatus[requestedName] = "missing"
-		}
-
-		// Check all backups in cluster against requested list
-		for _, backup := range backupList.Items {
-			if _, isRequested := requestedBackupsStatus[backup.Name]; isRequested {
-				// Create VM object for filtering check
-				vm := &kubevirtv1.VirtualMachine{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      vmbd.Spec.VirtualMachineName,
-						Namespace: vmbd.Spec.VirtualMachineNamespace,
-					},
-				}
-
-				// Check if backup is valid for this VM (basic spec filtering)
-				if velerohelpers.ValidateVMInBackupSpec(&backup, vm) {
-					requestedBackupsStatus[backup.Name] = "candidate" // Will go through discovery
-				} else {
-					requestedBackupsStatus[backup.Name] = "filtered" // Exists but filtered out
-				}
-			}
-		}
-
-		// Process the results
-		for requestedName, status := range requestedBackupsStatus {
-			switch status {
-			case "missing":
-				invalidBackups = append(invalidBackups, types.InvalidBackupInfo{
-					VeleroBackupInfo: types.VeleroBackupInfo{
-						Name:      requestedName,
-						Namespace: r.OADPNamespace,
-					},
-					Reason: "Backup not found in cluster",
-				})
-				missingBackupsCount++
-
-			case "filtered":
-				// Add to filtered out backups that will show in backupDiscoveryProgress
-				filteredOutBackups = append(filteredOutBackups, types.BackupDiscoveryProgress{
-					VeleroBackupInfo: types.VeleroBackupInfo{
-						Name:      requestedName,
-						Namespace: r.OADPNamespace,
-						// Note: We can't easily get CreatedAt for filtered backups here without another lookup
-					},
-					Status:      types.BackupDiscoveryStatusSkipped,
-					Message:     "Backup doesn't include target VM namespace",
-					LastUpdated: &metav1.Time{Time: time.Now()},
-				})
-				// "candidate" status backups are already in the candidates slice and will be processed normally
-			}
-		}
-
 		// Always set invalidBackups for explicit requests (even if empty)
 		// This ensures missing backups are properly tracked
 		vmbd.Status.InvalidBackups = invalidBackups
@@ -448,6 +397,106 @@ func (r *VirtualMachineBackupsDiscoveryReconciler) initializeDiscovery(ctx conte
 	logger.V(4).Info("Started backup discovery", "candidates", len(candidates))
 	logger.V(1).Info("Discovery initialized", "candidates", len(candidates))
 	return true, nil // Requeue to start processing
+}
+
+// classifyRequestedBackups classifies explicitly requested backups into categories:
+// - missing: backup not found in cluster
+// - filtered: backup exists but doesn't include target VM namespace
+// - async-incomplete: backup has incomplete async operations (data mover upload not finished)
+// - candidate: backup is valid and will go through discovery
+// Returns invalidBackups, missingBackupsCount, and filteredOutBackups
+func (r *VirtualMachineBackupsDiscoveryReconciler) classifyRequestedBackups(
+	vmbd *oadpv1alpha1.VirtualMachineBackupsDiscovery,
+	backupList *velerov1api.BackupList,
+) ([]types.InvalidBackupInfo, int, []types.BackupDiscoveryProgress) {
+	var invalidBackups []types.InvalidBackupInfo
+	var missingBackupsCount int
+	var filteredOutBackups []types.BackupDiscoveryProgress
+
+	if len(vmbd.Spec.RequestedBackups) == 0 {
+		return invalidBackups, missingBackupsCount, filteredOutBackups
+	}
+
+	// Check which requested backups exist and classify them
+	requestedBackupsStatus := make(map[string]string) // name -> status: "missing", "filtered", "candidate", "async-incomplete"
+	for _, requestedName := range vmbd.Spec.RequestedBackups {
+		requestedBackupsStatus[requestedName] = "missing"
+	}
+
+	// Check all backups in cluster against requested list
+	// Store backup references for later use in async reason generation
+	backupRefs := make(map[string]*velerov1api.Backup)
+	for i := range backupList.Items {
+		backup := &backupList.Items[i]
+		if _, isRequested := requestedBackupsStatus[backup.Name]; isRequested {
+			backupRefs[backup.Name] = backup
+
+			// Check for incomplete async operations first (e.g., data mover upload not finished)
+			if velerohelpers.BackupAsyncOperationsIncomplete(backup) {
+				requestedBackupsStatus[backup.Name] = "async-incomplete"
+				continue
+			}
+
+			// Create VM object for filtering check
+			vm := &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmbd.Spec.VirtualMachineName,
+					Namespace: vmbd.Spec.VirtualMachineNamespace,
+				},
+			}
+
+			// Check if backup is valid for this VM (basic spec filtering)
+			if velerohelpers.ValidateVMInBackupSpec(backup, vm) {
+				requestedBackupsStatus[backup.Name] = "candidate" // Will go through discovery
+			} else {
+				requestedBackupsStatus[backup.Name] = "filtered" // Exists but filtered out
+			}
+		}
+	}
+
+	// Process the results
+	for requestedName, status := range requestedBackupsStatus {
+		switch status {
+		case "missing":
+			invalidBackups = append(invalidBackups, types.InvalidBackupInfo{
+				VeleroBackupInfo: types.VeleroBackupInfo{
+					Name:      requestedName,
+					Namespace: r.OADPNamespace,
+				},
+				Reason: "Backup not found in cluster",
+			})
+			missingBackupsCount++
+
+		case "filtered":
+			// Add to filtered out backups that will show in backupDiscoveryProgress
+			filteredOutBackups = append(filteredOutBackups, types.BackupDiscoveryProgress{
+				VeleroBackupInfo: types.VeleroBackupInfo{
+					Name:      requestedName,
+					Namespace: r.OADPNamespace,
+				},
+				Status:      types.BackupDiscoveryStatusSkipped,
+				Message:     "Backup doesn't include target VM namespace",
+				LastUpdated: &metav1.Time{Time: time.Now()},
+			})
+
+		case "async-incomplete":
+			// Backup exists but has incomplete async operations (data mover upload not finished)
+			reason := velerohelpers.BackupAsyncOperationsReason(backupRefs[requestedName])
+			if reason == "" {
+				reason = "Backup has incomplete async operations"
+			}
+			invalidBackups = append(invalidBackups, types.InvalidBackupInfo{
+				VeleroBackupInfo: types.VeleroBackupInfo{
+					Name:      requestedName,
+					Namespace: r.OADPNamespace,
+					CreatedAt: function.GetBackupTimestamp(backupRefs[requestedName]),
+				},
+				Reason: reason,
+			})
+		}
+	}
+
+	return invalidBackups, missingBackupsCount, filteredOutBackups
 }
 
 // processDiscoveryBatch continues the discovery process by checking pending backups

--- a/internal/controller/virtualmachinebackupsdiscovery_controller_test.go
+++ b/internal/controller/virtualmachinebackupsdiscovery_controller_test.go
@@ -726,6 +726,118 @@ var _ = Describe("VirtualMachineBackupsDiscovery Controller Comprehensive Tests"
 			})
 		})
 
+		Describe("BackupAsyncOperationsIncomplete", func() {
+			It("should return false for nil backup", func() {
+				result := velerohelpers.BackupAsyncOperationsIncomplete(nil)
+				Expect(result).To(BeFalse())
+			})
+
+			It("should return false when no async operations were attempted", func() {
+				backup := &velerov1api.Backup{
+					Status: velerov1api.BackupStatus{
+						BackupItemOperationsAttempted: 0,
+						BackupItemOperationsCompleted: 0,
+					},
+				}
+				result := velerohelpers.BackupAsyncOperationsIncomplete(backup)
+				Expect(result).To(BeFalse())
+			})
+
+			It("should return false when all async operations completed successfully", func() {
+				backup := &velerov1api.Backup{
+					Status: velerov1api.BackupStatus{
+						BackupItemOperationsAttempted: 3,
+						BackupItemOperationsCompleted: 3,
+					},
+				}
+				result := velerohelpers.BackupAsyncOperationsIncomplete(backup)
+				Expect(result).To(BeFalse())
+			})
+
+			It("should return true when async operations are incomplete (none completed)", func() {
+				backup := &velerov1api.Backup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "incomplete-backup",
+						Namespace: "velero",
+					},
+					Status: velerov1api.BackupStatus{
+						Phase:                         velerov1api.BackupPhaseCompleted,
+						BackupItemOperationsAttempted: 1,
+						BackupItemOperationsCompleted: 0, // DataUpload finished after backup was marked complete
+					},
+				}
+				result := velerohelpers.BackupAsyncOperationsIncomplete(backup)
+				Expect(result).To(BeTrue())
+			})
+
+			It("should return true when async operations are partially completed", func() {
+				backup := &velerov1api.Backup{
+					Status: velerov1api.BackupStatus{
+						BackupItemOperationsAttempted: 5,
+						BackupItemOperationsCompleted: 3,
+					},
+				}
+				result := velerohelpers.BackupAsyncOperationsIncomplete(backup)
+				Expect(result).To(BeTrue())
+			})
+
+			It("should return false when completed equals attempted (even with failures)", func() {
+				// This tests the case where all operations completed, but some failed
+				// The backup is still "complete" in terms of async operations
+				backup := &velerov1api.Backup{
+					Status: velerov1api.BackupStatus{
+						BackupItemOperationsAttempted: 3,
+						BackupItemOperationsCompleted: 3,
+						BackupItemOperationsFailed:    1,
+					},
+				}
+				result := velerohelpers.BackupAsyncOperationsIncomplete(backup)
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Describe("BackupAsyncOperationsReason", func() {
+			It("should return empty string for nil backup", func() {
+				result := velerohelpers.BackupAsyncOperationsReason(nil)
+				Expect(result).To(BeEmpty())
+			})
+
+			It("should return empty string when no async operations attempted", func() {
+				backup := &velerov1api.Backup{
+					Status: velerov1api.BackupStatus{
+						BackupItemOperationsAttempted: 0,
+					},
+				}
+				result := velerohelpers.BackupAsyncOperationsReason(backup)
+				Expect(result).To(BeEmpty())
+			})
+
+			It("should return empty string when all operations completed", func() {
+				backup := &velerov1api.Backup{
+					Status: velerov1api.BackupStatus{
+						BackupItemOperationsAttempted: 1,
+						BackupItemOperationsCompleted: 1,
+					},
+				}
+				result := velerohelpers.BackupAsyncOperationsReason(backup)
+				Expect(result).To(BeEmpty())
+			})
+
+			It("should return detailed reason when operations are incomplete", func() {
+				backup := &velerov1api.Backup{
+					Status: velerov1api.BackupStatus{
+						BackupItemOperationsAttempted: 1,
+						BackupItemOperationsCompleted: 0,
+						BackupItemOperationsFailed:    0,
+					},
+				}
+				result := velerohelpers.BackupAsyncOperationsReason(backup)
+				Expect(result).To(ContainSubstring("incomplete async operations"))
+				Expect(result).To(ContainSubstring("BackupItemOperationsAttempted=1"))
+				Expect(result).To(ContainSubstring("BackupItemOperationsCompleted=0"))
+			})
+		})
+
 		Describe("mapBackupToVMBD", func() {
 			var (
 				backupObj *velerov1api.Backup

--- a/internal/controller/virtualmachinefilerestore_controller.go
+++ b/internal/controller/virtualmachinefilerestore_controller.go
@@ -1530,6 +1530,16 @@ func (r *VirtualMachineFileRestoreReconciler) getBackupMetadata(
 		return oadptypes.BackupDiscoveryProgress{}, fmt.Errorf("failed to get Velero backup metadata: %w", err)
 	}
 
+	// Validate backup async operations are complete (e.g., data mover upload finished)
+	// This is a secondary validation - VMBD should have already filtered out incomplete backups
+	if velerohelpers.BackupAsyncOperationsIncomplete(veleroBackup) {
+		reason := velerohelpers.BackupAsyncOperationsReason(veleroBackup)
+		if reason == "" {
+			reason = "backup has incomplete async operations"
+		}
+		return oadptypes.BackupDiscoveryProgress{}, fmt.Errorf("%s", reason)
+	}
+
 	// Initialize progress with backup metadata
 	now := metav1.Now()
 	progress := oadptypes.BackupDiscoveryProgress{

--- a/internal/velerohelpers/backup_discovery_utils.go
+++ b/internal/velerohelpers/backup_discovery_utils.go
@@ -108,3 +108,64 @@ func extractKindFromGVK(gvk string) string {
 
 	return string(parts[start:end])
 }
+
+// BackupAsyncOperationsIncomplete checks if a backup has incomplete async operations.
+// This is used to validate that backups with data mover operations (e.g., snapshotMoveData: true)
+// have completed all their async operations before being considered valid for restore.
+//
+// Returns true if the backup has async operations that haven't completed (backup is NOT ready for restore).
+// Returns false if:
+//   - No async operations were attempted (BackupItemOperationsAttempted == 0)
+//   - All async operations completed successfully (Completed == Attempted)
+//
+// This prevents attempting restores from backups where the data mover upload completed
+// after the backup was marked as Completed, leaving BackupItemOperationsCompleted unset.
+func BackupAsyncOperationsIncomplete(backup *veleroapi.Backup) bool {
+	if backup == nil || backup.Status.BackupItemOperationsAttempted == 0 {
+		// No async operations attempted, backup is ready
+		return false
+	}
+
+	// If attempted > 0, completed must equal attempted for the backup to be ready
+	return backup.Status.BackupItemOperationsCompleted != backup.Status.BackupItemOperationsAttempted
+}
+
+// BackupAsyncOperationsReason returns a human-readable reason for why a backup's async operations are incomplete.
+// Returns empty string if async operations are complete or not applicable.
+func BackupAsyncOperationsReason(backup *veleroapi.Backup) string {
+	if backup == nil || backup.Status.BackupItemOperationsAttempted == 0 {
+		return ""
+	}
+
+	if backup.Status.BackupItemOperationsCompleted != backup.Status.BackupItemOperationsAttempted {
+		return "backup has incomplete async operations (data mover upload may not have finished); " +
+			"BackupItemOperationsAttempted=" + itoa(backup.Status.BackupItemOperationsAttempted) +
+			", BackupItemOperationsCompleted=" + itoa(backup.Status.BackupItemOperationsCompleted) +
+			", BackupItemOperationsFailed=" + itoa(backup.Status.BackupItemOperationsFailed)
+	}
+
+	return ""
+}
+
+// itoa converts an integer to a string without importing strconv
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	negative := i < 0
+	if negative {
+		i = -i
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if negative {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}

--- a/internal/velerohelpers/backup_discovery_utils_test.go
+++ b/internal/velerohelpers/backup_discovery_utils_test.go
@@ -345,6 +345,235 @@ func TestParseNamespacedName(t *testing.T) {
 	}
 }
 
+func TestBackupAsyncOperationsIncomplete(t *testing.T) {
+	tests := []struct {
+		name     string
+		backup   *veleroapi.Backup
+		expected bool
+	}{
+		{
+			name:     "nil backup - should return false (not incomplete)",
+			backup:   nil,
+			expected: false,
+		},
+		{
+			name: "no async operations attempted - should return false",
+			backup: &veleroapi.Backup{
+				Status: veleroapi.BackupStatus{
+					BackupItemOperationsAttempted: 0,
+					BackupItemOperationsCompleted: 0,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "all async operations completed - should return false",
+			backup: &veleroapi.Backup{
+				Status: veleroapi.BackupStatus{
+					BackupItemOperationsAttempted: 1,
+					BackupItemOperationsCompleted: 1,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "multiple async operations all completed - should return false",
+			backup: &veleroapi.Backup{
+				Status: veleroapi.BackupStatus{
+					BackupItemOperationsAttempted: 5,
+					BackupItemOperationsCompleted: 5,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "async operations attempted but none completed (zero) - should return true",
+			backup: &veleroapi.Backup{
+				Status: veleroapi.BackupStatus{
+					BackupItemOperationsAttempted: 1,
+					BackupItemOperationsCompleted: 0,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "async operations partially completed - should return true",
+			backup: &veleroapi.Backup{
+				Status: veleroapi.BackupStatus{
+					BackupItemOperationsAttempted: 3,
+					BackupItemOperationsCompleted: 2,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "async operations with some failures but all accounted for - should return false",
+			backup: &veleroapi.Backup{
+				Status: veleroapi.BackupStatus{
+					BackupItemOperationsAttempted: 3,
+					BackupItemOperationsCompleted: 3,
+					BackupItemOperationsFailed:    1,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "backup marked complete before DataUpload finished (race condition scenario) - should return true",
+			backup: &veleroapi.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backupvmtest1",
+					Namespace: "openshift-adp",
+				},
+				Status: veleroapi.BackupStatus{
+					Phase:                         veleroapi.BackupPhaseCompleted,
+					BackupItemOperationsAttempted: 1,
+					BackupItemOperationsCompleted: 0, // Never updated because backup finalized prematurely
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BackupAsyncOperationsIncomplete(tt.backup)
+			if result != tt.expected {
+				t.Errorf("BackupAsyncOperationsIncomplete() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBackupAsyncOperationsReason(t *testing.T) {
+	tests := []struct {
+		name           string
+		backup         *veleroapi.Backup
+		expectEmpty    bool
+		expectContains []string
+	}{
+		{
+			name:        "nil backup - should return empty",
+			backup:      nil,
+			expectEmpty: true,
+		},
+		{
+			name: "no async operations - should return empty",
+			backup: &veleroapi.Backup{
+				Status: veleroapi.BackupStatus{
+					BackupItemOperationsAttempted: 0,
+				},
+			},
+			expectEmpty: true,
+		},
+		{
+			name: "all completed - should return empty",
+			backup: &veleroapi.Backup{
+				Status: veleroapi.BackupStatus{
+					BackupItemOperationsAttempted: 1,
+					BackupItemOperationsCompleted: 1,
+				},
+			},
+			expectEmpty: true,
+		},
+		{
+			name: "incomplete operations - should return detailed reason",
+			backup: &veleroapi.Backup{
+				Status: veleroapi.BackupStatus{
+					BackupItemOperationsAttempted: 1,
+					BackupItemOperationsCompleted: 0,
+					BackupItemOperationsFailed:    0,
+				},
+			},
+			expectEmpty: false,
+			expectContains: []string{
+				"incomplete async operations",
+				"BackupItemOperationsAttempted=1",
+				"BackupItemOperationsCompleted=0",
+				"BackupItemOperationsFailed=0",
+			},
+		},
+		{
+			name: "partially completed with failures - should return detailed reason",
+			backup: &veleroapi.Backup{
+				Status: veleroapi.BackupStatus{
+					BackupItemOperationsAttempted: 5,
+					BackupItemOperationsCompleted: 3,
+					BackupItemOperationsFailed:    1,
+				},
+			},
+			expectEmpty: false,
+			expectContains: []string{
+				"BackupItemOperationsAttempted=5",
+				"BackupItemOperationsCompleted=3",
+				"BackupItemOperationsFailed=1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BackupAsyncOperationsReason(tt.backup)
+
+			if tt.expectEmpty {
+				if result != "" {
+					t.Errorf("BackupAsyncOperationsReason() = %q, expected empty string", result)
+				}
+				return
+			}
+
+			if result == "" {
+				t.Error("BackupAsyncOperationsReason() returned empty string, expected non-empty reason")
+				return
+			}
+
+			for _, substr := range tt.expectContains {
+				if !containsSubstring(result, substr) {
+					t.Errorf("BackupAsyncOperationsReason() = %q, expected to contain %q", result, substr)
+				}
+			}
+		})
+	}
+}
+
+// containsSubstring checks if s contains substr
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestItoa(t *testing.T) {
+	tests := []struct {
+		input    int
+		expected string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{10, "10"},
+		{123, "123"},
+		{-1, "-1"},
+		{-123, "-123"},
+		{1000000, "1000000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := itoa(tt.input)
+			if result != tt.expected {
+				t.Errorf("itoa(%d) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestExtractKindFromGVK(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
Fixes: [OADP-7344](https://issues.redhat.com//browse/OADP-7344)

  Backups using data mover (snapshotMoveData: true) can be marked
  Completed before DataUpload finishes, leaving BackupItemOperationsCompleted
  unset. Restoring from such backups fails silently.

  Add validation to check BackupItemOperationsCompleted == BackupItemOperationsAttempted
  before accepting backups for discovery or restore:
  - VMBD: Filter out incomplete backups; mark as invalid when explicitly requested
  - VMFR: Secondary validation before creating Velero Restore objects