### PR TITLE
Add podName info in VMFR status field

### DIFF
--- a/api/v1alpha1/virtualmachinefilerestore_types.go
+++ b/api/v1alpha1/virtualmachinefilerestore_types.go
@@ -329,6 +329,7 @@ type FileBrowserServingInfo struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Discovery",type=string,JSONPath=`.spec.backupsDiscoveryRef`
+// +kubebuilder:printcolumn:name="Namespace",type=string,JSONPath=`.status.createdNamespace`
 // +kubebuilder:printcolumn:name="Pod",type=string,JSONPath=`.status.fileServingInfo.podName`
 
 // VirtualMachineFileRestore is the Schema for the virtualmachinefilerestores API

--- a/api/v1alpha1/virtualmachinefilerestore_types.go
+++ b/api/v1alpha1/virtualmachinefilerestore_types.go
@@ -329,7 +329,7 @@ type FileBrowserServingInfo struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Discovery",type=string,JSONPath=`.spec.backupsDiscoveryRef`
-// +kubebuilder:printcolumn:name="Namespace",type=string,JSONPath=`.status.createdNamespace`
+// +kubebuilder:printcolumn:name="Pod-NS",type=string,JSONPath=`.status.createdNamespace`
 // +kubebuilder:printcolumn:name="Pod",type=string,JSONPath=`.status.fileServingInfo.podName`
 
 // VirtualMachineFileRestore is the Schema for the virtualmachinefilerestores API

--- a/api/v1alpha1/virtualmachinefilerestore_types.go
+++ b/api/v1alpha1/virtualmachinefilerestore_types.go
@@ -271,6 +271,10 @@ type RestoreInfo struct {
 
 // FileServingInfo summarizes how restored files can be accessed
 type FileServingInfo struct {
+	// PodName is the name of the file server pod created in the restore namespace.
+	// +optional
+	PodName string `json:"podName,omitempty"`
+
 	// SSH contains SSH/SFTP/SCP/rsync access information, if enabled.
 	// +optional
 	SSH *SSHServingInfo `json:"ssh,omitempty"`

--- a/config/crd/bases/oadp.openshift.io_virtualmachinefilerestores.yaml
+++ b/config/crd/bases/oadp.openshift.io_virtualmachinefilerestores.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .spec.backupsDiscoveryRef
       name: Discovery
       type: string
+    - jsonPath: .status.createdNamespace
+      name: Namespace
+      type: string
     - jsonPath: .status.fileServingInfo.podName
       name: Pod
       type: string

--- a/config/crd/bases/oadp.openshift.io_virtualmachinefilerestores.yaml
+++ b/config/crd/bases/oadp.openshift.io_virtualmachinefilerestores.yaml
@@ -24,7 +24,7 @@ spec:
       name: Discovery
       type: string
     - jsonPath: .status.createdNamespace
-      name: Namespace
+      name: Pod-NS
       type: string
     - jsonPath: .status.fileServingInfo.podName
       name: Pod

--- a/config/crd/bases/oadp.openshift.io_virtualmachinefilerestores.yaml
+++ b/config/crd/bases/oadp.openshift.io_virtualmachinefilerestores.yaml
@@ -249,6 +249,10 @@ spec:
                 description: Information about the file serving resources that have
                   been created.
                 properties:
+                  podName:
+                    description: PodName is the name of the file server pod created
+                      in the restore namespace.
+                    type: string
                   fileBrowser:
                     description: FileBrowser contains HTTPS file browser access information,
                       if enabled.

--- a/internal/controller/virtualmachinefilerestore_controller.go
+++ b/internal/controller/virtualmachinefilerestore_controller.go
@@ -2077,13 +2077,19 @@ func (r *VirtualMachineFileRestoreReconciler) updateFileServingInfo(
 	vmfr *oadpv1alpha1.VirtualMachineFileRestore,
 	service *corev1.Service,
 ) error {
+	// Assign to vmfr.Status immediately so PodName is always persisted even if
+	// the function returns early (e.g. restoreNamespace not yet set in status).
+	fileServingInfo := &oadpv1alpha1.FileServingInfo{
+		PodName: fmt.Sprintf("%s-fileserver", vmfr.Name),
+	}
+	vmfr.Status.FileServingInfo = fileServingInfo
+
 	restoreNamespace := vmfr.Status.CreatedNamespace
 	if restoreNamespace == "" {
 		return fmt.Errorf("restore namespace not set in status")
 	}
 
 	serviceName := service.Name
-	fileServingInfo := &oadpv1alpha1.FileServingInfo{}
 
 	// Build SSH serving info if SSH is enabled
 	if vmfr.Spec.FileAccess != nil && vmfr.Spec.FileAccess.SSH != nil {
@@ -2160,11 +2166,9 @@ func (r *VirtualMachineFileRestoreReconciler) updateFileServingInfo(
 		fileServingInfo.FileBrowser = fbInfo
 	}
 
-	// Update FileServingInfo in vmfr.Status
-	// Note: Status is NOT persisted here - caller will do a single status update
-	// to avoid race conditions from multiple status updates
-	vmfr.Status.FileServingInfo = fileServingInfo
-
+	// Status is NOT persisted here - caller does a single atomic status patch.
+	// fileServingInfo was already assigned to vmfr.Status.FileServingInfo above,
+	// so SSH/FileBrowser fields set above are already reflected in the status.
 	logger.V(0).Info("Prepared file serving info for status update",
 		"sshClusterAccess", func() string {
 			if fileServingInfo.SSH != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restore status now shows the file server pod name used during virtual machine file restores, making it easier to identify which pod is serving restored files.
  * CRD display adds a Namespace column to show the restore namespace, improving visibility of where file-serving occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->