### PR TITLE
UPSTREAM: <carry>: Bump go to 1.25 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Bump the builder image to golang:1.25 to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build toolchain to the latest Go version for improved performance and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->