### PR TITLE
first pass at konflux.dockerfile

### DIFF
--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -1,0 +1,25 @@
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+COPY . .
+WORKDIR $APP_ROOT/app/
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+COPY cmd/main.go cmd/main.go
+COPY api/ api/
+COPY internal/ internal/
+ENV BUILDTAGS strictfipsruntime
+ENV GOEXPERIMENT strictfipsruntime
+RUN CGO_ENABLED=1 GOOS=linux go build -tags "$BUILDTAGS" -mod=mod -a -o manager cmd/main.go
+
+FROM registry.redhat.io/ubi9/ubi:latest
+COPY --from=builder $APP_ROOT/app/manager /manager
+
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]
+
+LABEL description="oadp-vmdp"
+LABEL io.k8s.description="oadp-vmdp"
+LABEL io.k8s.display-name="oadp-vmdp"
+LABEL io.openshift.tags="migration"
+LABEL summary="oadp-vmdp"


### PR DESCRIPTION
```
whayutin@fedora:~/OPENSHIFT/git/OADP/oadp-vm-file-restore$ podman build -f konflux.Dockerfile 
[1/2] STEP 1/12: FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
[1/2] STEP 2/12: COPY . .
--> 8bab5a95fae9
[1/2] STEP 3/12: WORKDIR $APP_ROOT/app/
--> 4ee3398914b0
[1/2] STEP 4/12: COPY go.mod go.mod
--> fa5cd7a22eef
[1/2] STEP 5/12: COPY go.sum go.sum
--> b9c9066dd4a1
[1/2] STEP 6/12: RUN go mod download
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: assessment: CGO_ENABLED=1
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: assessment: dynamic linking
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: skipping forced compliance due to broad exemption
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: EXEMPT: 1


Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: final command line arguments: "mod" "download" 

Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: invoking real go binary
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: Exited with: 0
--> 53bc2a7d7991
[1/2] STEP 7/12: COPY cmd/main.go cmd/main.go
--> 6dd805feb5d0
[1/2] STEP 8/12: COPY api/ api/
--> be12b598fe00
[1/2] STEP 9/12: COPY internal/ internal/
--> fb79d61d57e6
[1/2] STEP 10/12: ENV BUILDTAGS strictfipsruntime
--> defc70acbc53
[1/2] STEP 11/12: ENV GOEXPERIMENT strictfipsruntime
--> 705f2e566f13
[1/2] STEP 12/12: RUN CGO_ENABLED=1 GOOS=linux go build -tags "$BUILDTAGS" -mod=mod -a -o manager cmd/main.go
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: assessment: CGO_ENABLED=1
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: assessment: dynamic linking
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: skipping forced compliance due to broad exemption
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: EXEMPT: 1


Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: final command line arguments: "build" "-tags" "strictfipsruntime" "-mod=mod" "-a" "-o" "manager" "cmd/main.go" 

Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: invoking real go binary
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: Exited with: 0
--> 454c4b557df9
[2/2] STEP 1/9: FROM registry.redhat.io/ubi9/ubi:latest
[2/2] STEP 2/9: COPY --from=builder $APP_ROOT/app/manager /manager
--> d2de065141da
[2/2] STEP 3/9: USER 65532:65532
--> 00bfe5249626
[2/2] STEP 4/9: ENTRYPOINT ["/manager"]
--> dc17eb40d452
[2/2] STEP 5/9: LABEL description="oadp-vmdp"
--> 6719ed0b2268
[2/2] STEP 6/9: LABEL io.k8s.description="oadp-vmdp"
--> 3c6a406cadd7
[2/2] STEP 7/9: LABEL io.k8s.display-name="oadp-vmdp"
--> 14d73575bd25
[2/2] STEP 8/9: LABEL io.openshift.tags="migration"
--> f6af8f0612ba
[2/2] STEP 9/9: LABEL summary="oadp-vmdp"
[2/2] COMMIT
--> 690716460a11
690716460a11b28f281007093feebd1da40121ae2b47563d68debf87020c408d

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added optimized containerized build configuration with multi-stage compilation pattern and non-root user execution for enhanced deployment efficiency and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->