### PR TITLE
UPSTREAM: <carry>: Bump konflux.Dockerfile Go base image to 1.25

### DIFF
--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
 COPY . .
 WORKDIR $APP_ROOT/app/
 COPY go.mod go.mod


### PR DESCRIPTION
## Summary
- Bumps the Go builder image from `rhel_9_golang_1.24` to `rhel_9_golang_1.25` in `konflux.Dockerfile` to stay in sync with other OADP components (e.g. oadp-operator).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>