### PR TITLE
UPSTREAM: <carry>: Fix konflux.Dockerfile COPY paths for multi-image repo

### DIFF
--- a/containers/oadp-vmfr-access/konflux.Dockerfile
+++ b/containers/oadp-vmfr-access/konflux.Dockerfile
@@ -20,7 +20,7 @@ LABEL name="oadp-vmfr-access" \
       version="1.5.0"
 
 # Install required licenses
-COPY LICENSE /licenses/LICENSE
+COPY containers/oadp-vmfr-access/LICENSE /licenses/LICENSE
 
 # ==============================================================================
 # Package Installation - All required tools for VM disk and filesystem access
@@ -142,8 +142,8 @@ RUN dnf install -y \
 # Copy helper scripts into container
 # - detect-and-mount.sh: Auto-detects disk formats and mounts filesystems read-only
 # - entrypoint.sh: Simple entrypoint that keeps container alive
-COPY scripts/detect-and-mount.sh /usr/local/bin/detect-and-mount.sh
-COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY containers/oadp-vmfr-access/scripts/detect-and-mount.sh /usr/local/bin/detect-and-mount.sh
+COPY containers/oadp-vmfr-access/scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Make scripts executable
 RUN chmod +x /usr/local/bin/detect-and-mount.sh /usr/local/bin/entrypoint.sh

--- a/containers/side-containers/sshd/konflux.Dockerfile
+++ b/containers/side-containers/sshd/konflux.Dockerfile
@@ -1,12 +1,12 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
 WORKDIR /workspace
-COPY oadp-sshd.go .
+COPY containers/side-containers/sshd/oadp-sshd.go .
 ENV GOEXPERIMENT strictfipsruntime
 RUN CGO_ENABLED=1 GOOS=linux go build -tags strictfipsruntime -ldflags="-s -w" -o oadp-sshd oadp-sshd.go
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest
 
-COPY LICENSE /licenses/LICENSE
+COPY containers/side-containers/sshd/LICENSE /licenses/LICENSE
 
 # Install required packages
 RUN microdnf install -y \
@@ -61,7 +61,7 @@ RUN for binary in /usr/bin/rsync /usr/bin/scp /bin/bash /usr/libexec/openssh/sft
 COPY --from=builder /workspace/oadp-sshd /oadp/bin/oadp-sshd
 
 # Copy entrypoint script
-COPY entrypoint.sh /entrypoint.sh
+COPY containers/side-containers/sshd/entrypoint.sh /entrypoint.sh
 
 # Make binaries executable
 RUN chmod 711 /oadp/bin/oadp-sshd \


### PR DESCRIPTION
## Summary
- Fix COPY paths in `containers/side-containers/sshd/konflux.Dockerfile` and `containers/oadp-vmfr-access/konflux.Dockerfile`
- Konflux builds use the repo root as the build context, so COPY instructions in subdirectory Dockerfiles must use full paths from the repo root
- Without this fix, builds fail with: `copier: stat: "/oadp-sshd.go": no such file or directory`

## Changes
**`containers/side-containers/sshd/konflux.Dockerfile`:**
- `COPY oadp-sshd.go .` → `COPY containers/side-containers/sshd/oadp-sshd.go .`
- `COPY LICENSE /licenses/LICENSE` → `COPY containers/side-containers/sshd/LICENSE /licenses/LICENSE`
- `COPY entrypoint.sh /entrypoint.sh` → `COPY containers/side-containers/sshd/entrypoint.sh /entrypoint.sh`

**`containers/oadp-vmfr-access/konflux.Dockerfile`:**
- `COPY LICENSE /licenses/LICENSE` → `COPY containers/oadp-vmfr-access/LICENSE /licenses/LICENSE`
- `COPY scripts/detect-and-mount.sh ...` → `COPY containers/oadp-vmfr-access/scripts/detect-and-mount.sh ...`
- `COPY scripts/entrypoint.sh ...` → `COPY containers/oadp-vmfr-access/scripts/entrypoint.sh ...`

## Test plan
- [ ] Verify Konflux builds succeed for oadp-vmfr-access-sshd
- [ ] Verify Konflux builds succeed for oadp-vmfr-access

🤖 Generated with [Claude Code](https://claude.com/claude-code)