### PR TITLE
Set GOTOOLCHAIN=go1.25.7 in konflux.Dockerfiles

### DIFF
--- a/containers/side-containers/sshd/konflux.Dockerfile
+++ b/containers/side-containers/sshd/konflux.Dockerfile
@@ -1,4 +1,5 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+ENV GOTOOLCHAIN=go1.25.7
 WORKDIR /workspace
 COPY containers/side-containers/sshd/oadp-sshd.go .
 ENV GOEXPERIMENT strictfipsruntime

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -1,4 +1,5 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+ENV GOTOOLCHAIN=go1.25.7
 COPY . .
 WORKDIR $APP_ROOT/app/
 COPY go.mod go.mod


### PR DESCRIPTION
## Summary
- Override `toolchain go1.25.8` from go.mod with `GOTOOLCHAIN=go1.25.7` in Konflux builder stages
- Applied to both `konflux.Dockerfile` and `containers/side-containers/sshd/konflux.Dockerfile`
- go1.25.8 is not yet available in the builder image; this pins to go1.25.7 to unblock builds

## Test plan
- [ ] Konflux build succeeds with go1.25.7 for both images