### PR TITLE
Fix konflux Dockerfile packages for RHEL 9 compatibility

### DIFF
--- a/containers/oadp-vmfr-access/BUILD.md
+++ b/containers/oadp-vmfr-access/BUILD.md
@@ -176,24 +176,22 @@ For Konflux configuration, see Red Hat internal documentation.
 
 #### Error: "No package libguestfs-tools available"
 
-**Cause:** Fedora version too old or mirrors not synced.
+**Cause:** In RHEL 9, `libguestfs-tools` does not exist as a separate package. The `guestmount`, `guestfish`, and `guestunmount` binaries are provided by the base `libguestfs` package.
 
-**Fix:**
-1. Verify Fedora 42 is available: https://fedoraproject.org/
-2. Try with explicit mirror: `dnf install --setopt=fastestmirror=false ...`
+**Fix:** Use `libguestfs` instead of `libguestfs-tools` in the Dockerfile.
 
 ### Konflux Build Issues
 
-#### Error: "Unable to find a match: libguestfs-tools"
+#### Error: "Unable to find a match: libguestfs"
 
-**Cause:** Running konflux.Dockerfile outside the Konflux environment.
+**Cause:** Running konflux.Dockerfile outside the Konflux environment. Packages like `libguestfs`, `qemu-img`, `e2fsprogs`, `xfsprogs`, `dosfstools`, `parted`, and `gdisk` are in RHEL AppStream/BaseOS repos, not in the free UBI repos.
 
 **Fix:** Use the Fedora Dockerfile for local development:
 ```bash
 podman build -f Dockerfile -t oadp-vmfr-access:dev .
 ```
 
-The konflux.Dockerfile is designed for automated Konflux builds only.
+The konflux.Dockerfile is designed for automated Konflux builds only (which have access to full RHEL repos).
 
 ### Build is Slow
 

--- a/containers/oadp-vmfr-access/README.md
+++ b/containers/oadp-vmfr-access/README.md
@@ -4,7 +4,7 @@ Design and create container with tools to access restored file systems
 
 ## Overview
 
-This container provides a standardized environment with comprehensive tools to access and mount VM disk images (qcow2, raw) and various filesystems (ext4, xfs, ntfs, btrfs, etc.) from Velero/OADP backups. It serves as a toolbox for the VMFR (VirtualMachineFileRestore) controller to create file-serving pods.
+This container provides a standardized environment with comprehensive tools to access and mount VM disk images (qcow2, raw) and various filesystems (ext4, xfs, ntfs, fat) from Velero/OADP backups. It serves as a toolbox for the VMFR (VirtualMachineFileRestore) controller to create file-serving pods.
 
 ## Key Concepts
 
@@ -52,7 +52,7 @@ Understanding the core technologies that make this container work:
 - ✅ No kernel modules required (unlike NBD - Network Block Device)
 - ✅ Safer than kernel-level mounting
 - ✅ Works in containers without dangerous kernel access
-- ✅ Standard technology (used by sshfs, ntfs-3g, many others)
+- ✅ Standard technology (used by sshfs, libguestfs, many others)
 
 **Security advantage:** All filesystem code runs as a regular process, not in the kernel.
 
@@ -98,7 +98,7 @@ Without KVM:  libguestfs ready in 5+ minutes  ❌ (often times out)
 After researching KubeVirt's approach and VM filesystem requirements, we chose an **all-in-one container** approach over a plugin architecture:
 
 **Rationale:**
-- ✅ **Limited, well-defined set**: VM filesystem types are finite and well-known (ext4, xfs, ntfs, btrfs, fat)
+- ✅ **Limited, well-defined set**: VM filesystem types are finite and well-known (ext4, xfs, ntfs, fat)
 - ✅ **Lightweight tooling**: All required packages combined are relatively small (~200-300MB)
 - ✅ **Simpler deployment**: Single image, no plugin management complexity
 - ✅ **Easier debugging**: All tools in one place, straightforward troubleshooting
@@ -154,11 +154,12 @@ This section explains **why** we need each tool and **what** it does, so everyon
 
 #### Category 1: VM Disk Image Tools
 
-**`libguestfs-tools`** - **CRITICAL: Our primary tool**
+**`libguestfs`** - **CRITICAL: Our primary tool**
 - **Why:** Allows accessing VM disk images without starting the VM
-- **What:** Provides `guestmount` (FUSE-based mounting), `guestfish` (disk inspection), and tools to read/modify disk images
+- **What:** Provides `guestmount` (FUSE-based mounting), `guestfish` (disk inspection), `guestunmount`, and tools to read/modify disk images
 - **Use Case:** Mount backed-up VM disks to extract files without booting the VM
 - **Example:** `guestmount -a disk.qcow2 -i /mnt/disk --ro`
+- **Note:** In RHEL 9, `guestmount`/`guestfish` are in the base `libguestfs` package (`libguestfs-tools` does not exist as a separate package in el9)
 
 **`libguestfs-xfs`** - **CRITICAL: Required for RHEL/CentOS VMs**
 - **Why:** XFS is the default filesystem for RHEL 7+, CentOS 7+, Fedora (most common in OpenShift)
@@ -199,17 +200,17 @@ This section explains **why** we need each tool and **what** it does, so everyon
 - **Use Case:** Access ext4 filesystems inside VM disk images
 - **Coverage:** ~15% of VMs (Ubuntu/Debian-based)
 
-**`btrfs-progs`** - **Btrfs (SUSE, modern Fedora)**
-- **Why:** Btrfs is used in SUSE Linux, some Fedora installations
-- **What:** Tools to read Btrfs filesystems (copy-on-write, snapshots)
-- **Use Case:** Access Btrfs filesystems if VM uses it
-- **Coverage:** ~3% of VMs
-
-**`ntfs-3g`** - **NTFS (Windows Server VMs)**
+**`libguestfs-winsupport`** - **NTFS (Windows Server VMs)**
 - **Why:** NTFS is the Windows filesystem
-- **What:** FUSE-based NTFS driver for reading/writing Windows filesystems
+- **What:** Injects NTFS driver into the libguestfs appliance via supermin
 - **Use Case:** Access Windows Server VM disk images
 - **Coverage:** ~2% of VMs (Windows workloads)
+- **Note:** Replaces `ntfs-3g` which is only available in EPEL, not in RHEL repos. Available in RHEL 9 AppStream.
+
+> **Btrfs is NOT supported:** Red Hat deprecated Btrfs in RHEL 7 and fully removed it in RHEL 8+.
+> There is no `btrfs-progs` in RHEL 9 repos (only available via EPEL), and the libguestfs appliance
+> kernel (based on RHEL) lacks the `btrfs.ko` module. VMs using Btrfs (primarily SUSE guests)
+> cannot be mounted. This is a known limitation.
 
 **`dosfstools`** - **FAT32 (EFI System Partitions)**
 - **Why:** FAT32 is used for EFI System Partitions (ESP) on **all** UEFI VMs
@@ -300,10 +301,14 @@ Uses `guestmount` from libguestfs instead of NBD for Kubernetes compatibility:
 **Supported Filesystems:**
 - ext2/ext3/ext4 (Linux)
 - XFS (Linux)
-- Btrfs (Linux)
-- NTFS (Windows)
+- NTFS (Windows) — via `libguestfs-winsupport`
 - FAT/FAT32 (boot partitions)
 - LVM (Logical Volume Manager)
+- ~~Btrfs~~ — not supported on RHEL 9 (no kernel module or userspace tools available)
+
+**Not Supported:**
+- **LUKS-encrypted VM disks** — `cryptsetup` is not included; guestmount cannot unlock encrypted partitions. Supporting LUKS would also require passing decryption keys via Kubernetes Secrets and CRD changes, not just a package install.
+- **Btrfs filesystems** — removed from RHEL 8+; primarily affects SUSE guest VMs
 
 **Read-Only Safety:**
 - All filesystems mounted with `--ro` (read-only)

--- a/containers/oadp-vmfr-access/konflux.Dockerfile
+++ b/containers/oadp-vmfr-access/konflux.Dockerfile
@@ -32,11 +32,14 @@ RUN dnf install -y \
     # =========================================================================
     # Category 1: VM Disk Image Tools - CRITICAL for reading VM disk images
     # =========================================================================
-    # libguestfs-tools: PRIMARY TOOL - Mount VM disks without booting the VM
-    #   - Provides: guestmount (FUSE-based mounting), guestfish (inspection)
+    # libguestfs: PRIMARY TOOL - Mount VM disks without booting the VM
+    #   - Provides: guestmount (FUSE-based mounting), guestfish (inspection),
+    #     guestunmount, virt-copy-in, virt-copy-out, virt-tar-in, virt-tar-out
     #   - Use case: Mount backed-up qcow2/raw disk images to extract files
     #   - Example: guestmount -a disk.qcow2 -i /mnt/disk --ro
-    libguestfs-tools \
+    #   - Note: In RHEL 9, guestmount/guestfish moved into the base libguestfs
+    #     package (libguestfs-tools does not exist as a separate package in el9)
+    libguestfs \
     #
     # libguestfs-xfs: CRITICAL - Required for RHEL/CentOS/Fedora VMs
     #   - Why: XFS is default filesystem for RHEL 7+, CentOS 7+, Fedora
@@ -74,16 +77,26 @@ RUN dnf install -y \
     #   - Coverage: ~80% of OpenShift VMs
     xfsprogs \
     #
-    # btrfs-progs: Btrfs filesystem support (SUSE, modern Fedora)
-    #   - Why: Btrfs used in SUSE Linux, some Fedora installations
-    #   - Coverage: ~3% of VMs
-    btrfs-progs \
-    #
-    # ntfs-3g: NTFS filesystem support (Windows Server VMs)
+    # libguestfs-winsupport: NTFS filesystem support (Windows Server VMs)
     #   - Why: NTFS is the Windows filesystem
-    #   - What: FUSE-based NTFS driver for reading/writing Windows filesystems
+    #   - What: Injects NTFS driver into the libguestfs appliance via supermin
+    #   - Available in: RHEL 9 AppStream (official Red Hat package)
+    #   - Note: Replaces ntfs-3g which is only available in EPEL, not in RHEL repos
     #   - Coverage: ~2% of VMs (Windows workloads)
-    ntfs-3g \
+    libguestfs-winsupport \
+    #
+    # NOTE: Btrfs is NOT supported on RHEL 9
+    #   - Red Hat deprecated Btrfs in RHEL 7 and fully removed it in RHEL 8+
+    #   - No kernel module (btrfs.ko), no btrfs-progs, no libguestfs-btrfs in RHEL 9
+    #   - btrfs-progs is only available via EPEL, and even then the libguestfs
+    #     appliance kernel (based on RHEL) lacks the btrfs module
+    #   - Impact: VMs using Btrfs (primarily SUSE guests) cannot be mounted
+    #
+    # NOTE: LUKS-encrypted VM disks are NOT supported
+    #   - cryptsetup is not included; guestmount cannot unlock encrypted partitions
+    #   - Supporting LUKS would also require passing decryption keys via Kubernetes
+    #     Secrets and CRD changes — not just a package install
+    #
     #
     # dosfstools: FAT12/FAT16/FAT32 filesystem support (EFI System Partitions)
     #   - Why: FAT32 used for EFI System Partitions (ESP) on ALL UEFI VMs
@@ -111,29 +124,19 @@ RUN dnf install -y \
     gdisk \
     #
     # =========================================================================
-    # Category 5: Utility Tools - Detection & Debugging
+    # Category 5: Utility Tools
     # =========================================================================
+    # Pre-installed in UBI9 base image (no need to install explicitly):
+    #   - util-linux (lsblk, blkid, mount, mountpoint)
+    #   - findutils (find, xargs)
+    #   - coreutils-single (mkdir, basename, date, sleep, ls, cat, etc.)
+    #     Note: Do NOT install 'coreutils' — it conflicts with coreutils-single
+    #   - python3 (JSON parsing in detect-and-mount.sh)
+    #
     # file: File type detection by content (magic numbers)
     #   - Why: Verify actual file type, not just extension
     #   - Example: file disk.qcow2 → "QEMU QCOW2 Image (v3)"
     file \
-    #
-    # util-linux: Block device utilities
-    #   - Provides: lsblk, blkid, mount
-    #   - Use case: Inspect mounted filesystems, debug block devices
-    util-linux \
-    #
-    # findutils, coreutils: Standard Unix tools
-    #   - Provides: find, ls, cat, grep, awk, etc.
-    #   - Use case: Used by detect-and-mount.sh automation scripts
-    findutils \
-    coreutils \
-    #
-    # python3: Python interpreter for JSON parsing
-    #   - Why: detect-and-mount.sh uses Python for parsing BACKUP_PVC_MAP JSON
-    #   - What: Provides reliable JSON parsing (more robust than jq or bash)
-    #   - Use case: Parse backup-to-PVC mapping from VMFR controller
-    python3 \
     #
     # Clean up dnf cache to reduce image size
     && dnf clean all \

--- a/containers/oadp-vmfr-access/scripts/detect-and-mount.sh
+++ b/containers/oadp-vmfr-access/scripts/detect-and-mount.sh
@@ -17,10 +17,10 @@
 # Supported Filesystems:
 #   - ext2/ext3/ext4 (Linux)
 #   - XFS (Linux)
-#   - Btrfs (Linux)
-#   - NTFS (Windows)
+#   - NTFS (Windows) — via libguestfs-winsupport
 #   - FAT/FAT32 (Boot partitions, Windows)
 #   - LVM (Logical Volume Manager)
+#   Note: Btrfs is NOT supported on RHEL 9 (no kernel module or userspace tools)
 #
 # Directory Structure:
 #   When BACKUP_PVC_MAP is provided, creates structured mounts:
@@ -161,7 +161,7 @@ detect_disk_format() {
 #
 # guestmount capabilities:
 #   - Auto-detects partitions and filesystems (-i flag)
-#   - Supports LVM, RAID, encryption
+#   - Supports LVM, RAID (encryption/LUKS is NOT supported)
 #   - Works with qcow2, raw, vmdk, vdi formats
 #   - Read-only mounting for data safety
 #


### PR DESCRIPTION
Fix konflux Dockerfile packages for RHEL 9 compatibility

- Replace libguestfs-tools with libguestfs (no separate -tools package in el9)
- Replace ntfs-3g with libguestfs-winsupport (ntfs-3g is EPEL-only)
- Drop btrfs-progs (removed from RHEL since 8, no kernel module)
- Drop coreutils/findutils/util-linux/python3 (pre-installed in UBI9)
- Document unsupported: Btrfs filesystems, LUKS-encrypted disks